### PR TITLE
VehicleJourneysCtl#collection: Use VehicleJourney.with_stops

### DIFF
--- a/app/controllers/vehicle_journeys_controller.rb
+++ b/app/controllers/vehicle_journeys_controller.rb
@@ -77,15 +77,7 @@ class VehicleJourneysController < ChouetteController
 
   protected
   def collection
-    scope = route.vehicle_journeys
-      .joins(:journey_pattern)
-      .joins('
-        LEFT JOIN "vehicle_journey_at_stops"
-          ON "vehicle_journey_at_stops"."vehicle_journey_id" = "vehicle_journeys"."id"
-          AND "vehicle_journey_at_stops"."stop_point_id" =
-            "journey_patterns"."departure_stop_point_id"
-      ')
-      .order("vehicle_journey_at_stops.departure_time")
+    scope = route.vehicle_journeys.with_stops
 
     @q = scope.search filtered_ransack_params
     grouping = ransack_periode_filter


### PR DESCRIPTION
Use the class method to get the vehicle journeys in the proper order of
departure time ascending.

The `.with_stops` method replicates this same SQL sequence of joins and
order.

Refs #3268