### PR TITLE
_vj_collection.sass: Remove z-index from .has-error:before

### DIFF
--- a/app/assets/stylesheets/modules/_vj_collection.sass
+++ b/app/assets/stylesheets/modules/_vj_collection.sass
@@ -92,7 +92,6 @@
           left: 0
           right: 0
           bottom: 0
-          z-index: 5
           border: 2px solid $red
 
         > .th


### PR DESCRIPTION
When an error occurred when modifying a time in a journey pattern, it
would be surrounded by a red box. The trouble is, you wouldn't be able
to click inside that box to focus the inputs and change times once the
box was added.

The problem happens on this page:
http://stif-boiv.dev:3000/referentials/4/lines/158/routes/1/vehicle_journeys

This was due to the z-index placing the box on a layer closer to the
front than the inputs, eating click events and preventing them from
being clicked on.

Originally I thought about using `pointer-events: none;` but according
to http://caniuse.com/#search=pointer-events it isn't supported in
IE < 11. Eliminated the `z-index` instead which has the same effect and
doesn't appear to cause any visual problems, at least on the page I
mentioned. Only tested in Opera TBH.

Refs #3301

Here's what the problem looks like:
![stif-boiv-bug--vehicle-journeys-horaires--cant-click-under-error-box](https://cloud.githubusercontent.com/assets/342964/25713492/2881adb2-30f5-11e7-9544-4e20a587e669.gif)
