### PR TITLE
vehicle_journeys/reducers/filters_spec: Fix CREATE_QUERY_STRING test

### DIFF
--- a/spec/javascripts/vehicle_journeys/reducers/filters_spec.js
+++ b/spec/javascripts/vehicle_journeys/reducers/filters_spec.js
@@ -146,7 +146,16 @@ describe('filters reducer', () => {
   })
 
   it('should handle CREATE_QUERY_STRING', () => {
-    let strResult = "q%5Bjourney_pattern_id_eq%5D=undefined&q%5Bobjectid_cont%5D=undefined&q%5Btime_tables_id_eq%5D=undefined&q%5Bvehicle_journey_at_stops_departure_time_gteq%5D=11%3A11&q%5Bvehicle_journey_at_stops_departure_time_lteq%5D=22%3A22&q%5Bvehicle_journey_without_departure_time%5D=true"
+    let strResult = [
+      "q%5Bjourney_pattern_id_eq%5D=undefined",
+      "&q%5Bobjectid_cont%5D=undefined",
+      "&q%5Btime_tables_id_eq%5D=undefined",
+      "&q%5Bvehicle_journey_at_stops_departure_time_gteq%5D=11%3A11",
+      "&q%5Bvehicle_journey_at_stops_departure_time_lteq%5D=22%3A22",
+      "&q%5Bvehicle_journey_without_departure_time%5D=true",
+      "&q%5Bvehicle_journey_without_time_table%5D=true"
+    ].join('')
+
     expect(
       statusReducer(state, {
         type: 'CREATE_QUERY_STRING',


### PR DESCRIPTION
My change to add the `vehicle_journey_without_time_table` filter option
in c84330abb5f52d42e1aa7ec9e5db930d8e23163e broke this test because my
change modified the query string. Add in the new
`vehicle_journey_without_time_table` param to the expected query string.

Also rewrite the string as an array to make it a little easier to read.