### PR TITLE
Revert "Revert "time_duration_spec.rb: Make old test style uniform with new tests"

### DIFF
--- a/spec/lib/time_duration_spec.rb
+++ b/spec/lib/time_duration_spec.rb
@@ -4,15 +4,17 @@ describe TimeDuration do
   describe ".exceeds_gap?" do
     context "when duration is 4.hours" do
       it "should return false if gap < 1.hour" do
-        t1 = Time.now
-        t2 = Time.now + 3.minutes
-        expect(TimeDuration.exceeds_gap?(4.hours, t1, t2)).to be_falsey
+        earlier = Time.now
+        later = Time.now + 3.minutes
+
+        expect(TimeDuration.exceeds_gap?(4.hours, earlier, later)).to be false
       end
 
       it "should return true if gap > 4.hour" do
-        t1 = Time.now
-        t2 = Time.now + (4.hours + 1.minutes)
-        expect(TimeDuration.exceeds_gap?(4.hours, t1, t2)).to be_truthy
+        earlier = Time.now
+        later = Time.now + (4.hours + 1.minutes)
+
+        expect(TimeDuration.exceeds_gap?(4.hours, earlier, later)).to be true
       end
 
       it "returns true when `earlier` is later than `later`" do


### PR DESCRIPTION
Reinstate the updated `TimeDuration` spec code. Turns out this was
reverted by accident. Robert was doing a complicated merge/rebase and
somehow in the mix this commit ended up being unintentionally reverted.