### PR TITLE
Add 'spring-commands-rspec'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -146,6 +146,7 @@ group :development do
   gem 'quiet_assets'
   gem 'license_finder'
   gem 'bundler-audit'
+  gem 'spring-commands-rspec'
 
   platforms :ruby_20, :ruby_21, :ruby_22 do
     gem 'better_errors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -492,6 +492,8 @@ GEM
     slop (3.6.0)
     spring (2.0.1)
       activesupport (>= 4.2)
+    spring-commands-rspec (1.0.4)
+      spring (>= 0.9.1)
     sprockets (2.12.4)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -651,6 +653,7 @@ DEPENDENCIES
   sinatra
   slim-rails (~> 3.1)
   spring
+  spring-commands-rspec
   sqlite3
   squeel!
   teaspoon-jasmine


### PR DESCRIPTION
This gem allows RSpec to be used with the Spring preloader, eliminating
the Rails startup time when running tests. Was getting really annoyed at
the 10-second startup times every time I wanted to run any tests.

Here's a sample comparison running a single test file:

    Before:

    rspec spec/models/chouette/vehicle_journey_at_stops_day_offset_spec.rb
    Run options:
      include {:wip=>true}
      exclude {:js=>true, :meta=>true}

    All examples were filtered out; ignoring {:wip=>true}
    ...

    Finished in 2.01 seconds (files took 9.41 seconds to load)
    3 examples, 0 failures

    ---

    After:

    spring rspec spec/models/chouette/vehicle_journey_at_stops_day_offset_spec.rb
    Running via Spring preloader in process 45340
    Run options:
      include {:wip=>true}
      exclude {:js=>true, :meta=>true}

    All examples were filtered out; ignoring {:wip=>true}
    ...

    Finished in 2 seconds (files took 0.76843 seconds to load)
    3 examples, 0 failures

When doing TDD this is a huge workflow improvement.

Since the `/bin/` directory is ignored by .gitignore, you'll have to
generate the binstub manually to get this working:

    $ bundle exec spring binstub rspec
    $ git checkout bin/spring  # since this file is in the repo but is
    $                          # also in .gitignore so shouldn't be
    $                          # committed.
    $ bundle exec spring rspec  # enjoy!

To use with rspec.vim, add this to your Vim config:

    let g:rspec_command = "!bundle exec spring rspec {spec}"