### PR TITLE
Add 'dbshell-rails' gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -147,6 +147,7 @@ group :development do
   gem 'license_finder'
   gem 'bundler-audit'
   gem 'spring-commands-rspec'
+  gem 'dbshell-rails'
 
   platforms :ruby_20, :ruby_21, :ruby_22 do
     gem 'better_errors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,6 +180,7 @@ GEM
     daemons (1.2.4)
     database_cleaner (1.5.3)
     dbf (3.1.0)
+    dbshell-rails (0.0.2)
     debug_inspector (0.0.2)
     deep_cloneable (2.0.2)
       activerecord (>= 3.1.0, < 5.0.0)
@@ -579,6 +580,7 @@ DEPENDENCIES
   cucumber-rails
   daemons
   database_cleaner
+  dbshell-rails
   deep_cloneable (~> 2.0.0)
   devise (~> 3.5.4)
   devise-async


### PR DESCRIPTION
This is a personal optimisation. If it doesn't make sense to add to the
project, we can remove it.

I want to be able to open the application's database console quickly at
times, and this gem lets me do that.