### PR TITLE
3846 vehicle journeys  fix filter by hour to make end time inclusive

### DIFF
--- a/app/models/chouette/vehicle_journey.rb
+++ b/app/models/chouette/vehicle_journey.rb
@@ -256,7 +256,7 @@ module Chouette
         .where(
           %Q(
             "vehicle_journey_at_stops"."departure_time" >= ?
-            AND "vehicle_journey_at_stops"."departure_time" < ?
+            AND "vehicle_journey_at_stops"."departure_time" <= ?
             #{
               if allow_empty
                 'OR "vehicle_journey_at_stops"."id" IS NULL'

--- a/spec/models/chouette/vehicle_journey_spec.rb
+++ b/spec/models/chouette/vehicle_journey_spec.rb
@@ -404,6 +404,35 @@ describe Chouette::VehicleJourney, :type => :model do
         .to_a
       ).to eq([journey])
     end
+
+    it "uses an inclusive range" do
+      journey_early = create(
+        :vehicle_journey,
+        stop_departure_time: '03:00:00'
+      )
+
+      route = journey_early.route
+      journey_pattern = journey_early.journey_pattern
+
+      journey_late = create(
+        :vehicle_journey,
+        route: route,
+        journey_pattern: journey_pattern,
+        stop_departure_time: '04:00:00'
+      )
+
+      expect(route
+        .vehicle_journeys
+        .select('DISTINCT "vehicle_journeys".*')
+        .joins('
+          LEFT JOIN "vehicle_journey_at_stops"
+            ON "vehicle_journey_at_stops"."vehicle_journey_id" =
+              "vehicle_journeys"."id"
+        ')
+        .where_departure_time_between('03:00', '04:00', allow_empty: true)
+        .to_a
+      ).to eq([journey_early, journey_late])
+    end
   end
 
   describe ".without_time_tables" do


### PR DESCRIPTION
In VehicleJourneys#index, the filter by hour wasn't including vehicle journeys with departure times equal to the end time in the filtered range. I had incorrectly replicated the functionality, using `<` instead of `<=`. Make the departure time range filter inclusive.