### PR TITLE
VehicleJourney spec: Fix "uses an inclusive range" array matcher

### DIFF
--- a/spec/models/chouette/vehicle_journey_spec.rb
+++ b/spec/models/chouette/vehicle_journey_spec.rb
@@ -431,7 +431,7 @@ describe Chouette::VehicleJourney, :type => :model do
         ')
         .where_departure_time_between('03:00', '04:00', allow_empty: true)
         .to_a
-      ).to eq([journey_early, journey_late])
+      ).to match_array([journey_early, journey_late])
     end
   end
 


### PR DESCRIPTION
I had used `eq` because I was copying the other tests in
`.where_departure_time_between`, but those matched only a single element
inside the array. Here, since we're maching more than one, we need to
use `match_array` in order to disregard the element order.

Didn't notice this at first because it worked on my local machine. In
fact, it continued to work even after several tries. Needed to manually
reverse the element order in order to get the test to fail. Cédric
pointed out that my test was failing on CI.

Refs #3846