### PR TITLE
Fix errors from JS-formatted templates using the table_builder

### DIFF
--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -16,14 +16,13 @@ class CompaniesController < BreadcrumbController
           redirect_to params.merge(:page => 1)
         end
 
-        @companies = ModelDecorator.decorate(
-          @companies,
-          with: CompanyDecorator,
-          context: {
-            referential: line_referential
-          }
-        )
+        @companies = decorate_companies(@companies)
       }
+
+      format.json {
+        @companies = decorate_companies(@companies)
+      }
+
       build_breadcrumb :index
     end
   end
@@ -75,6 +74,16 @@ class CompaniesController < BreadcrumbController
   end
   def sort_direction
     %w[asc desc].include?(params[:direction]) ?  params[:direction] : 'asc'
+  end
+
+  def decorate_companies(companies)
+    ModelDecorator.decorate(
+      companies,
+      with: CompanyDecorator,
+      context: {
+        referential: line_referential
+      }
+    )
   end
 
 end

--- a/app/controllers/networks_controller.rb
+++ b/app/controllers/networks_controller.rb
@@ -37,14 +37,13 @@ class NetworksController < BreadcrumbController
           redirect_to params.merge(:page => 1)
         end
 
-        @networks = ModelDecorator.decorate(
-          @networks,
-          with: NetworkDecorator,
-          context: {
-            line_referential: line_referential
-          }
-        )
+        @networks = decorate_networks(@networks)
       }
+
+      format.js {
+        @networks = decorate_networks(@networks)
+      }
+
       build_breadcrumb :index
     end
   end
@@ -85,6 +84,16 @@ class NetworksController < BreadcrumbController
   end
   def sort_direction
     %w[asc desc].include?(params[:direction]) ?  params[:direction] : 'asc'
+  end
+
+  def decorate_networks(networks)
+    ModelDecorator.decorate(
+      networks,
+      with: NetworkDecorator,
+      context: {
+        line_referential: line_referential
+      }
+    )
   end
 
 end

--- a/app/controllers/referential_companies_controller.rb
+++ b/app/controllers/referential_companies_controller.rb
@@ -14,14 +14,13 @@ class ReferentialCompaniesController < ChouetteController
           redirect_to params.merge(:page => 1)
         end
 
-        @companies = ModelDecorator.decorate(
-          @companies,
-          with: CompanyDecorator,
-          context: {
-            referential: referential
-          }
-        )
+        @companies = decorate_companies(@companies)
       }
+
+      format.js {
+        @companies = decorate_companies(@companies)
+      }
+
       build_breadcrumb :index
     end
   end
@@ -68,6 +67,16 @@ class ReferentialCompaniesController < ChouetteController
   end
   def sort_direction
     %w[asc desc].include?(params[:direction]) ?  params[:direction] : 'asc'
+  end
+
+  def decorate_companies(companies)
+    ModelDecorator.decorate(
+      companies,
+      with: CompanyDecorator,
+      context: {
+        referential: referential
+      }
+    )
   end
 
 end

--- a/app/controllers/referential_networks_controller.rb
+++ b/app/controllers/referential_networks_controller.rb
@@ -30,14 +30,13 @@ class ReferentialNetworksController < ChouetteController
           redirect_to params.merge(:page => 1)
         end
 
-        @networks = ModelDecorator.decorate(
-          @networks,
-          with: ReferentialNetworkDecorator,
-          context: {
-            referential: referential
-          }
-        )
+        @networks = decorate_networks(@networks)
       }
+
+      format.js {
+        @networks = decorate_networks(@networks)
+      }
+
       build_breadcrumb :index
     end
   end
@@ -79,6 +78,16 @@ class ReferentialNetworksController < ChouetteController
   end
   def sort_direction
     %w[asc desc].include?(params[:direction]) ?  params[:direction] : 'asc'
+  end
+
+  def decorate_networks(networks)
+    ModelDecorator.decorate(
+      networks,
+      with: ReferentialNetworkDecorator,
+      context: {
+        referential: referential
+      }
+    )
   end
 
 end

--- a/app/controllers/time_tables_controller.rb
+++ b/app/controllers/time_tables_controller.rb
@@ -86,15 +86,13 @@ class TimeTablesController < ChouetteController
           redirect_to params.merge(:page => 1)
         end
 
-        @time_tables = ModelDecorator.decorate(
-          @time_tables,
-          with: TimeTableDecorator,
-          context: {
-            referential: @referential
-          }
-        )
+        @time_tables = decorate_time_tables(@time_tables)
 
         build_breadcrumb :index
+      }
+
+      format.js {
+        @time_tables = decorate_time_tables(@time_tables)
       }
     end
   end
@@ -193,6 +191,16 @@ class TimeTablesController < ChouetteController
   def duplicate_source
     from_id = time_table_params['created_from_id']
     Chouette::TimeTable.find(from_id) if from_id
+  end
+
+  def decorate_time_tables(time_tables)
+    ModelDecorator.decorate(
+      time_tables,
+      with: TimeTableDecorator,
+      context: {
+        referential: @referential
+      }
+    )
   end
 
   def time_table_params


### PR DESCRIPTION
We were getting errors like these:

    Started GET "/referentials/4/networks?_=1500482065840" for 127.0.0.1 at 2017-07-19 18:34:27 +0200
    Processing by ReferentialNetworksController#index as JS
      Parameters: {"_"=>"1500482065840", "referential_id"=>"4"}
      User Load (3.6ms)  SELECT  "public"."users".* FROM "public"."users" WHERE "public"."users"."id" = $1  ORDER BY "public"."users"."id" ASC LIMIT 1  [["id", 1]]
    locale set to :fr
      Organisation Load (5.6ms)  SELECT  "public"."organisations".* FROM "public"."organisations" WHERE "public"."organisations"."id" = $1 LIMIT 1  [["id", 1]]
      Referential Load (1.0ms)  SELECT  "public"."referentials".* FROM "public"."referentials" WHERE "public"."referentials"."organisation_id" = $1 AND "public"."referentials"."id" = $2 LIMIT 1  [["organisation_id", 1], ["id", 4]]
      Workbench Load (0.7ms)  SELECT  "public"."workbenches".* FROM "public"."workbenches" WHERE "public"."workbenches"."id" = $1 LIMIT 1  [["id", 1]]
       (1.3ms)  SELECT DISTINCT COUNT(DISTINCT "public"."networks"."id") FROM "public"."networks" INNER JOIN "public"."line_referentials" ON "public"."networks"."line_referential_id" = "public"."line_referentials"."id" WHERE "public"."line_referentials"."id" = $1  [["id", 1]]
      CACHE (0.0ms)  SELECT DISTINCT COUNT(DISTINCT "public"."networks"."id") FROM "public"."networks" INNER JOIN "public"."line_referentials" ON "public"."networks"."line_referential_id" = "public"."line_referentials"."id" WHERE "public"."line_referentials"."id" = $1  [["id", 1]]
      Chouette::Network Load (2.3ms)  SELECT  DISTINCT "public"."networks".* FROM "public"."networks" INNER JOIN "public"."line_referentials" ON "public"."networks"."line_referential_id" = "public"."line_referentials"."id" WHERE "public"."line_referentials"."id" = $1  ORDER BY name asc LIMIT 12 OFFSET 0  [["id", 1]]
      CACHE (0.0ms)  SELECT DISTINCT COUNT(DISTINCT "public"."networks"."id") FROM "public"."networks" INNER JOIN "public"."line_referentials" ON "public"."networks"."line_referential_id" = "public"."line_referentials"."id" WHERE "public"."line_referentials"."id" = $1  [["id", 1]]
      Chouette::Network Exists (1.2ms)  SELECT  1 AS one FROM "public"."networks" WHERE "public"."networks"."id" = $1 LIMIT 1  [["id", 118]]
      Rendered referential_networks/index.html.slim (48.9ms)
    Completed 500 Internal Server Error in 184ms (ActiveRecord: 17.4ms)

    ActionView::Template::Error (undefined method `action_links' for #<Chouette::Network:0x007ffea2148b08>):
        22:     - if @networks.any?
        23:       .row
        24:         .col-lg-12
        25:           = table_builder_2 @networks,
        26:             [ \
        27:               TableBuilderHelper::Column.new( \
        28:                 name: 'ID Codifligne', \
      app/helpers/table_builder_helper.rb:161:in `block in build_links'
      app/helpers/table_builder_helper.rb:158:in `build_links'
      app/helpers/table_builder_helper.rb:138:in `block (3 levels) in tbody'
      app/helpers/table_builder_helper.rb:110:in `block (2 levels) in tbody'
      app/helpers/table_builder_helper.rb:108:in `block in tbody'
      app/helpers/table_builder_helper.rb:107:in `tbody'
      app/helpers/table_builder_helper.rb:72:in `table_builder_2'
      app/views/referential_networks/index.html.slim:25:in `_app_views_referential_networks_index_html_slim___1557411244315414919_70366016986820'
      app/controllers/referential_networks_controller.rb:27:in `index'

      Rendered .../lib/ruby/gems/2.3.0/gems/actionpack-4.2.8/lib/action_dispatch/middleware/templates/rescues/_trace.text.erb (1.8ms)
      Rendered .../lib/ruby/gems/2.3.0/gems/actionpack-4.2.8/lib/action_dispatch/middleware/templates/rescues/_request_and_response.text.erb (2.5ms)
      Rendered .../lib/ruby/gems/2.3.0/gems/actionpack-4.2.8/lib/action_dispatch/middleware/templates/rescues/template_error.text.erb (76.0ms)

on the following pages:

- http://stif-boiv.dev:3000/referentials/4/time_tables
- http://stif-boiv.dev:3000/line_referentials/1/companies
- http://stif-boiv.dev:3000/line_referentials/1/networks
- http://stif-boiv.dev:3000/referentials/4/companies
- http://stif-boiv.dev:3000/referentials/4/networks

This was caused by the request of a JS-formatted view that rendered the
HTML template, since the collection decoration only happened in the HTML
format section.

Do the decoration in both the HTML format and JS format for the relevant
controllers in order to eliminate this error.

Maybe there's a cleaner way to do this than just duplicating the
decoration in both `format.X` blocks, but I don't know of it. Wanted to
make sure not to decorate when it wasn't necessary, like when rendering
other formats (XML, etc.).

Refs #4105