### PR TITLE
4401 create compliance control model attribute class

### DIFF
--- a/lib/model_attribute.rb
+++ b/lib/model_attribute.rb
@@ -21,6 +21,14 @@ class ModelAttribute
     all.group_by(&:klass)
   end
 
+  def self.from_code(code)
+    klass, name = code.split('#').map(&:to_sym)
+
+    methods_by_class(klass).select do |model_attr|
+      model_attr.name == name
+    end.first
+  end
+
   def self.methods_by_class(klass)
     all.select do |model_attr|
       model_attr.klass == klass

--- a/spec/lib/model_attribute_spec.rb
+++ b/spec/lib/model_attribute_spec.rb
@@ -30,6 +30,18 @@ RSpec.describe ModelAttribute do
     end
   end
 
+  describe ".from_code" do
+    it "returns a ModelAttribute from a given code" do
+      ModelAttribute.instance_variable_set(:@__all__, [
+        ModelAttribute.new(:journey_pattern, :name, :string)
+      ])
+
+      expect(ModelAttribute.from_code('journey_pattern#name')).to eq(
+        ModelAttribute.new(:journey_pattern, :name, :string)
+      )
+    end
+  end
+
   describe ".group_by_class" do
     it "returns all ModelAttributes grouped by klass" do
       ModelAttribute.instance_variable_set(:@__all__, [


### PR DESCRIPTION
A new model `ModelAttribute` that will enable Compliance Control to find fields on Chouette models that can be used in validations based on the types of those fields.