### PR TITLE
RansackDateFilter: Move `end` statement and jiggle indentation

### DIFF
--- a/app/controllers/concerns/ransack_date_filter.rb
+++ b/app/controllers/concerns/ransack_date_filter.rb
@@ -2,40 +2,41 @@ module RansackDateFilter
   extend ActiveSupport::Concern
   cattr_accessor :date_param
 
-    included do
+  included do
 
-      def set_date_time_params(param_name, klass)
-        start_date = []
-        end_date = []
+    def set_date_time_params(param_name, klass)
+      start_date = []
+      end_date = []
 
-        if params[:q] && params[:q][param_name] && !params[:q][param_name].has_value?(nil) && !params[:q][param_name].has_value?("")
-          [1, 2, 3].each do |key|
-            start_date <<  params[:q][param_name]["start_date(#{key}i)"].to_i
-            end_date <<  params[:q][param_name]["end_date(#{key}i)"].to_i
-          end
-          params[:q].delete([param_name])
-
-          if klass == DateTime
-            @begin_range = klass.new(*start_date,0,0,0) rescue nil
-            @end_range = klass.new(*end_date,23,59,59) rescue nil
-          else
-            @begin_range = klass.new(*start_date) rescue nil
-            @end_range = klass.new(*end_date) rescue nil
+      if params[:q] && params[:q][param_name] && !params[:q][param_name].has_value?(nil) && !params[:q][param_name].has_value?("")
+        [1, 2, 3].each do |key|
+          start_date <<  params[:q][param_name]["start_date(#{key}i)"].to_i
+          end_date <<  params[:q][param_name]["end_date(#{key}i)"].to_i
         end
-      end
 
-      # Fake ransack filter
-      def ransack_period_range **options
-        return options[:scope] unless !!@begin_range && !!@end_range
+        params[:q].delete([param_name])
 
-        if @begin_range > @end_range
-          flash.now[:error] = options[:error_message]
+        if klass == DateTime
+          @begin_range = klass.new(*start_date,0,0,0) rescue nil
+          @end_range = klass.new(*end_date,23,59,59) rescue nil
         else
-          scope = options[:scope].send options[:query], @begin_range..@end_range
+          @begin_range = klass.new(*start_date) rescue nil
+          @end_range = klass.new(*end_date) rescue nil
         end
-        scope
       end
     end
 
+    # Fake ransack filter
+    def ransack_period_range **options
+      return options[:scope] unless !!@begin_range && !!@end_range
+
+      if @begin_range > @end_range
+        flash.now[:error] = options[:error_message]
+      else
+        scope = options[:scope].send options[:query], @begin_range..@end_range
+      end
+      scope
+    end
   end
+
 end


### PR DESCRIPTION
An `end` statement was missing to close off the `set_date_time_params`
method. Wondering if this is what was causing these test failures on the
build server:

    1) ComplianceCheckSetsController GET index should be successful
       Failure/Error: scope = self.ransack_period_range(scope: @compliance_check_sets, error_message: t('compliance_check_sets.filters.error_period_filter'), query: :where_created_at_between)

       NoMethodError:
         undefined method `ransack_period_range' for #<ComplianceCheckSetsController:0x0000000fa67e58>
       # ./app/controllers/compliance_check_sets_controller.rb:11:in `block in index'
       # ./app/controllers/compliance_check_sets_controller.rb:10:in `index'
       # ./spec/controllers/compliance_check_sets_controller_spec.rb:17:in `block (3 levels) in <top (required)>'

    2) Workbenches permissions on show view if present →  shows the corresponding button
       Failure/Error: scope = self.ransack_period_range(scope: scope, error_message:  t('referentials.errors.validity_period'), query: :in_periode)

       NoMethodError:
         undefined method `ransack_period_range' for #<WorkbenchesController:0x00000006cb4368>
       # ./app/controllers/workbenches_controller.rb:15:in `show'
       # ./spec/features/workbenches_permissions_spec.rb:15:in `block (3 levels) in <top (required)>'

Worth a try.

Passes: http://ci.af83.priv/job/stif-boiv-branches/114/