### PR TITLE
compliance_check_resources: Rename `type` column to `resource_type`

### DIFF
--- a/db/migrate/20171113101005_change_type_to_resource_type_from_compliance_check_resources.rb
+++ b/db/migrate/20171113101005_change_type_to_resource_type_from_compliance_check_resources.rb
@@ -1,0 +1,5 @@
+class ChangeTypeToResourceTypeFromComplianceCheckResources < ActiveRecord::Migration
+  def change
+    rename_column :compliance_check_resources, :type, :resource_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171110130416) do
+ActiveRecord::Schema.define(version: 20171113101005) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -174,7 +174,7 @@ ActiveRecord::Schema.define(version: 20171110130416) do
   create_table "compliance_check_resources", id: :bigserial, force: :cascade do |t|
     t.string   "status"
     t.string   "name"
-    t.string   "type"
+    t.string   "resource_type"
     t.string   "reference"
     t.hstore   "metrics"
     t.datetime "created_at",                        null: false


### PR DESCRIPTION
The Java application needs a `resource_type` column to be able to store
the class/object that was validated by the resource's check. Since we
don't need or want Single Table Inheritance on this table, rename the
existing `type` field to `resource_type`.

Refs #4953