### PR TITLE
4951 spec to validate that primary and foreign keys in the database are type bigint

### DIFF
--- a/spec/db/schema_spec.rb
+++ b/spec/db/schema_spec.rb
@@ -16,7 +16,7 @@ RSpec::Matchers.define :use_bigint_keys do
 
         # Primary key
         if line =~ /create_table\s/ &&
-          !(line =~ /id:\s+(?::bigserial|false)/)
+          !(line =~ /id: \s+ (?: :bigserial | false)/x)
           expected_line = line.sub(/(create_table\s"\w+",\s)/, '\1id: :bigserial, ')
         end
 


### PR DESCRIPTION
A spec that checks the `schema.rb` file to make sure all primary and foreign keys defined in the application have type `bigint`.

We're required to use `bigint`s, but for the moment, this is enforced by convention only. Thus it's very easy to forget to type keys as `bigint` when creating new migrations.

This spec is a remedy for that forgetfulness.


## Testing

You can use or modify the following migration (or create your own) to test the spec:

``` ruby
# 20171114110225_test_bad_foreign_keys.rb
class TestBadForeignKeys < ActiveRecord::Migration
  def change
    create_table :bad_foreign_keys do |t|
      t.string :thing
      t.references :forei
      t.integer :quant
      t.references :anoth_for

      t.timestamps null: false
    end
  end
end
```


## Demo

RSpec output should look like this:

``` rspec
Failures:

  1) ActiveRecord::Schema uses type `bigint` for primary and foreign keys
     Failure/Error: expect('db/schema.rb').to use_bigint_keys
     
       expected "db/schema.rb" to use bigint keys
       Diff: 
       
       
       @@ -82,11 +82,11 @@
        
          add_index "api_keys", ["organisation_id"], name: "index_api_keys_on_organisation_id", using: :btree
        
       -  create_table "bad_foreign_keys", id: :bigserial, force: :cascade do |t|
       +  create_table "bad_foreign_keys", force: :cascade do |t|
            t.string   "thing"
       -    t.integer  "forei_id", limit: 8
       +    t.integer  "forei_id"
            t.integer  "quant"
       -    t.integer  "anoth_for_id", limit: 8
       +    t.integer  "anoth_for_id"
            t.datetime "created_at",   null: false
            t.datetime "updated_at",   null: false
          end
```
