### PR TITLE
NetexImport: Don't destroy non-existent Referentials

### DIFF
--- a/app/models/netex_import.rb
+++ b/app/models/netex_import.rb
@@ -17,7 +17,7 @@ class NetexImport < Import
   private
 
   def destroy_non_ready_referential
-    unless referential.ready
+    if referential && !referential.ready
       referential.destroy
     end
   end

--- a/spec/models/netex_import_spec.rb
+++ b/spec/models/netex_import_spec.rb
@@ -24,5 +24,16 @@ RSpec.describe NetexImport, type: :model do
         Referential.where(id: referential_ready_true.id).exists?
       ).to be true
     end
+
+    it "doesn't try to destroy nil referentials" do
+      workbench_import = create(:workbench_import)
+      create(
+        :netex_import,
+        parent: workbench_import,
+        referential: nil
+      )
+
+      expect { workbench_import.destroy }.not_to raise_error
+    end
   end
 end


### PR DESCRIPTION
Luc discovered this error in my method that destroys associated
non-ready `Referential`s:

    > WorkbenchImport.destroy_all
      WorkbenchImport Load (3.0ms)  SELECT "public"."imports".* FROM "public"."imports" WHERE "public"."imports"."type" IN ('WorkbenchImport')
       (1.5ms)  BEGIN
      ImportMessage Load (2.7ms)  SELECT "public"."import_messages".* FROM "public"."import_messages" WHERE "public"."import_messages"."import_id" = $1  [["import_id", 58]]
      ImportResource Load (1.9ms)  SELECT "public"."import_resources".* FROM "public"."import_resources" WHERE "public"."import_resources"."import_id" = $1  [["import_id", 58]]
      Import Load (0.3ms)  SELECT "public"."imports".* FROM "public"."imports" WHERE "public"."imports"."parent_id" = $1  [["parent_id", 58]]
      ImportMessage Load (0.5ms)  SELECT "public"."import_messages".* FROM "public"."import_messages" WHERE "public"."import_messages"."import_id" = $1  [["import_id", 59]]
      ImportResource Load (4.8ms)  SELECT "public"."import_resources".* FROM "public"."import_resources" WHERE "public"."import_resources"."import_id" = $1  [["import_id", 59]]
      SQL (1.3ms)  DELETE FROM "public"."import_resources" WHERE "public"."import_resources"."id" = $1  [["id", 636]]
      SQL (0.3ms)  DELETE FROM "public"."import_resources" WHERE "public"."import_resources"."id" = $1  [["id", 635]]
      SQL (0.2ms)  DELETE FROM "public"."import_resources" WHERE "public"."import_resources"."id" = $1  [["id", 634]]
      SQL (0.2ms)  DELETE FROM "public"."import_resources" WHERE "public"."import_resources"."id" = $1  [["id", 633]]
      SQL (0.2ms)  DELETE FROM "public"."import_resources" WHERE "public"."import_resources"."id" = $1  [["id", 632]]
      SQL (0.2ms)  DELETE FROM "public"."import_resources" WHERE "public"."import_resources"."id" = $1  [["id", 631]]
      SQL (0.2ms)  DELETE FROM "public"."import_resources" WHERE "public"."import_resources"."id" = $1  [["id", 630]]
      SQL (0.1ms)  DELETE FROM "public"."import_resources" WHERE "public"."import_resources"."id" = $1  [["id", 629]]
      SQL (0.2ms)  DELETE FROM "public"."import_resources" WHERE "public"."import_resources"."id" = $1  [["id", 628]]
      SQL (0.1ms)  DELETE FROM "public"."import_resources" WHERE "public"."import_resources"."id" = $1  [["id", 627]]
      SQL (0.1ms)  DELETE FROM "public"."import_resources" WHERE "public"."import_resources"."id" = $1  [["id", 626]]
      SQL (0.3ms)  DELETE FROM "public"."import_resources" WHERE "public"."import_resources"."id" = $1  [["id", 625]]
      SQL (0.3ms)  DELETE FROM "public"."import_resources" WHERE "public"."import_resources"."id" = $1  [["id", 624]]
      SQL (0.2ms)  DELETE FROM "public"."import_resources" WHERE "public"."import_resources"."id" = $1  [["id", 623]]
      SQL (0.2ms)  DELETE FROM "public"."import_resources" WHERE "public"."import_resources"."id" = $1  [["id", 622]]
      Import Load (0.3ms)  SELECT "public"."imports".* FROM "public"."imports" WHERE "public"."imports"."parent_id" = $1  [["parent_id", 59]]
      Referential Load (0.6ms)  SELECT  "public"."referentials".* FROM "public"."referentials" WHERE "public"."referentials"."id" = $1 LIMIT 1  [["id", 18]]
       (0.2ms)  ROLLBACK
    NoMethodError: undefined method `ready' for nil:NilClass
    from .../stif-boiv/app/models/netex_import.rb:20:in `destroy_non_ready_referential'

Since `referential` is not a required attribute, it can be nil. That was
causing this to break because I tried to destroy a `Referential` that
doesn't exist. Check that there's an associated `Referential` before
trying to destroy it.

Refs #4991