### PR TITLE
5005 make style of oui label in tables consistent with the normal text style

### DIFF
--- a/app/helpers/referentials_helper.rb
+++ b/app/helpers/referentials_helper.rb
@@ -1,5 +1,6 @@
 module ReferentialsHelper
-  # Line statuses helper
+  # Outputs a green check icon and the text "Oui" or a red exclamation mark
+  # icon and the text "Non" based on `status`
   def line_status(status)
     if status
       content_tag(:span, nil, class: 'fa fa-exclamation-circle fa-lg text-danger') +


### PR DESCRIPTION
Correctif pour le style du label "Oui" & "Non" dans la colonne "Activé".

Avant :

![screen shot 2017-11-06 at 5 20 28 pm](https://user-images.githubusercontent.com/342964/33075005-6a60314c-cec8-11e7-8bb0-b3d2847a6fe3.png)

Après :

![screen shot 2017-11-21 at 2 29 50 pm](https://user-images.githubusercontent.com/342964/33075031-7cf7ccd4-cec8-11e7-91b2-e18944ac3458.png)