### PR TITLE
0000 gemfile multiple nulldb entries [Mergabel, Low Priority, Low Hanging Fruit]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -139,7 +139,6 @@ gem 'rake'
 gem 'devise-async'
 gem 'apartment', '~> 1.0.0'
 gem 'aasm'
-gem 'activerecord-nulldb-adapter'
 gem 'puma', '~> 3.10.0'
 
 gem 'newrelic_rpm'


### PR DESCRIPTION
Pour éviter que bundler nous insulte (avec raison, on pourrait spécifier deux versions differents)

@fpeyraud est-ce ok que j'ai enlévé le `require: true` qui est implicite dans la ligne effacé.
Si t'en a besoin je change. Merci