### PR TITLE
initializers/sidekiq: Don't set Redis URL in development or test

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -7,9 +7,14 @@ Sidekiq.configure_server do |config|
       pendings.map { |sync| sync.failed({error: 'Failed by Sidekiq reboot', processing_time: 0}) }
     end
   end
-  config.redis = { url: ENV.fetch('SIDEKIQ_REDIS_URL', 'redis://redis:6379/12') }
 end
 
-Sidekiq.configure_client do |config|
-  config.redis = { url: ENV.fetch('SIDEKIQ_REDIS_URL', 'redis://redis:6379/12') }
+unless Rails.env.test? || Rails.env.development?
+  Sidekiq.configure_server do |config|
+    config.redis = { url: ENV.fetch('SIDEKIQ_REDIS_URL', 'redis://redis:6379/12') }
+  end
+
+  Sidekiq.configure_client do |config|
+    config.redis = { url: ENV.fetch('SIDEKIQ_REDIS_URL', 'redis://redis:6379/12') }
+  end
 end


### PR DESCRIPTION
Don't set this configuration in development and test environments to
enable Sidekiq to connect to the default Redis server by default without
setting the environment variable.