### PR TITLE
Fixes #5506@3h;

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,12 +11,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180105102012) do
+ActiveRecord::Schema.define(version: 20180108132310) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-  enable_extension "hstore"
   enable_extension "postgis"
+  enable_extension "hstore"
   enable_extension "unaccent"
 
   create_table "access_links", id: :bigserial, force: :cascade do |t|
@@ -990,6 +990,17 @@ ActiveRecord::Schema.define(version: 20180105102012) do
   add_index "workbenches", ["line_referential_id"], name: "index_workbenches_on_line_referential_id", using: :btree
   add_index "workbenches", ["organisation_id"], name: "index_workbenches_on_organisation_id", using: :btree
   add_index "workbenches", ["stop_area_referential_id"], name: "index_workbenches_on_stop_area_referential_id", using: :btree
+
+  create_table "workgroups", id: :bigserial, force: :cascade do |t|
+    t.string   "name"
+    t.integer  "line_referential_id",      limit: 8
+    t.integer  "stop_area_referential_id", limit: 8
+    t.datetime "created_at",                         null: false
+    t.datetime "updated_at",                         null: false
+  end
+
+  add_index "workgroups", ["line_referential_id"], name: "index_workgroups_on_line_referential_id", using: :btree
+  add_index "workgroups", ["stop_area_referential_id"], name: "index_workgroups_on_stop_area_referential_id", using: :btree
 
   add_foreign_key "access_links", "access_points", name: "aclk_acpt_fkey"
   add_foreign_key "api_keys", "organisations"

--- a/spec/support/referential.rb
+++ b/spec/support/referential.rb
@@ -60,7 +60,7 @@ RSpec.configure do |config|
       line_referential: line_referential,
       stop_area_referential: stop_area_referential
     )
-    referential = FactoryGirl.create(
+    FactoryGirl.create(
       :referential,
       prefix: "first",
       name: "first",
@@ -69,6 +69,19 @@ RSpec.configure do |config|
       workbench: workbench,
       objectid_format: "stif_netex"
     )
+  end
+
+  # Alas this still might not be sufficiant in certain cases (interruption of tests)
+  # to fix the problem of `rake db:rollback; rake db:migrate`. However the test database
+  # can also be cleanded by means of
+  # ```
+  #    RAILS_ENV=test bundle exec ruby -I. -r config/environment.rb -e 'Referential.pluck(:slug).each{|s|Apartment::Tenant.drop(s)};Referential.delete_all'` 
+  #
+  config.after :suite do
+    Referential.pluck(:slug).each do |name|
+      Apartment::Tenant.drop(name) rescue nil
+    end
+    Referential.delete_all
   end
 
   config.before(:each) do


### PR DESCRIPTION
Ceci est un bug Apartement strictement dit. Le PR implemente une roustine pour pouvoir faire des `bundle exec rake db:rollback` sur la BDD des tests.