### PR TITLE
5524-referentials-new--disable-submit-button-on-submit

### DIFF
--- a/app/views/referentials/_form.html.slim
+++ b/app/views/referentials/_form.html.slim
@@ -51,4 +51,8 @@
   .hidden = form.input :workbench_id, as: :hidden
 
 
-  = form.button :submit, t('actions.submit'), class: 'btn btn-default formSubmitr', form: 'referential_form'
+  = form.button :submit,
+      t('actions.submit'),
+      class: 'btn btn-default formSubmitr',
+      data: { disable_with: t('actions.processing') },
+      form: 'referential_form'

--- a/config/locales/actions.en.yml
+++ b/config/locales/actions.en.yml
@@ -7,6 +7,7 @@ en:
     delete: "Delete"
     search: "Search"
     submit: "Submit"
+    processing: "Processing…"
     add: "Add new"
     new: "Add new"
     show: "See"

--- a/config/locales/actions.fr.yml
+++ b/config/locales/actions.fr.yml
@@ -7,6 +7,7 @@ fr:
     delete: 'Supprimer'
     search: "Chercher"
     submit: "Valider"
+    processing: "En cours…"
     add: 'Créer'
     new: 'Créer'
     show: 'Consulter'


### PR DESCRIPTION
Désactive le bouton "Valider" après submit sur `Referentials#new` (http://stif-boiv.dev:3000/referentials/new?workbench_id=1). Ceci permet d'interdire les double-envois du formulaire dû aux double-clics du bouton. Fonctionne sur les formulaires du 'new' et du 'clone'.

![screen shot 2018-01-09 at 6 03 53 pm](https://user-images.githubusercontent.com/342964/34733190-cb6259f0-f567-11e7-8746-783ee7c5ce72.png)
