### PR TITLE
ReferentialVehicleJourneys#index: Fix `nil` error on `stop_area_ids`

### DIFF
--- a/app/controllers/referential_vehicle_journeys_controller.rb
+++ b/app/controllers/referential_vehicle_journeys_controller.rb
@@ -23,7 +23,7 @@ class ReferentialVehicleJourneysController < ChouetteController
     @vehicle_journeys ||= @q.result.order(:published_journey_name).includes(:vehicle_journey_at_stops).paginate page: params[:page], per_page: params[:per_page] || 10
     @all_companies = Chouette::Company.where("id IN (#{@referential.vehicle_journeys.select(:company_id).to_sql})").distinct
     @all_stop_areas = Chouette::StopArea.where("id IN (#{@referential.vehicle_journeys.joins(:stop_areas).select("stop_areas.id").to_sql})").distinct
-    stop_area_ids = params[:q][:stop_area_ids].select(&:present?)
+    stop_area_ids = params[:q].try(:[], :stop_area_ids).try(:select, &:present?)
     @filters_stop_areas = Chouette::StopArea.find(stop_area_ids) if stop_area_ids.present? && stop_area_ids.size <= 2
   end
 


### PR DESCRIPTION
This wasn't checking that `params[:q]` was present before trying to
access `[:stop_area_ids]`, and thus caused an error on the page when no
filters were applied.

Refs #5809