### PR TITLE
ImportResourcesDecorator: Fix `Draper::UninferrableDecoratorError`

### DIFF
--- a/app/decorators/import_resources_decorator.rb
+++ b/app/decorators/import_resources_decorator.rb
@@ -1,4 +1,4 @@
-class ImportResourcesDecorator < ModelDecorator
+class ImportResourcesDecorator < AF83::Decorator
   delegate :where
 
   def lines_imported


### PR DESCRIPTION
We were getting this error:

    Draper::UninferrableDecoratorError in ImportResources#index

    Showing .../stif-boiv/app/views/import_resources/index.html.slim where line #14 raised:

    Could not infer a decorator for ActiveRecord::Base.

    Extracted source (around line #14):

                span.status_icon = import_status(@import.status)
                span = t('.table_state', lines_imported: @import_resources.lines_imported , lines_in_zipfile: @import_resources.lines_in_zipfile )
            - if @import_resources.present?
              .col-lg-12
                h2 = t('.table_title')
              .col-lg-12

    Rails.root: .../stif-boiv
    Application Trace | Framework Trace | Full Trace

    app/views/import_resources/index.html.slim:14:in `_app_views_import_resources_index_html_slim___3139942318249059519_70240694466080'

when visiting this page:
http://stif-boiv.dev:3000/workbenches/1/imports/18/import_resources

Fix the error by inheriting from `AF83::Decorator` and having it take
care of things. We don't have any other model decorators that don't
inherit from `AF83::Decorator`, so this shouldn't be a problem any more.

Refs #5926