### PR TITLE
package.json: Upgrade node ~6.12.0 -> ~6.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "license": "MIT",
   "engines": {
-    "node": "~6.12.0"
+    "node": "~6.13.0"
   },
   "devDependencies": {
     "es6-object-assign": "1.1.0",


### PR DESCRIPTION
Our dev servers got their Debian packages upgraded recently and now the
project needs to use v6.13.x to align with the servers. Fixes our
Jenkins builds.

Refs #5929