### PR TITLE
5943 VehicleJourney#in_purchase_window: Use table namespace in query

### DIFF
--- a/app/models/chouette/vehicle_journey.rb
+++ b/app/models/chouette/vehicle_journey.rb
@@ -93,7 +93,7 @@ module Chouette
     scope :in_purchase_window, ->(range){
       purchase_windows = Chouette::PurchaseWindow.overlap_dates(range)
       sql = purchase_windows.joins(:vehicle_journeys).select('vehicle_journeys.id').uniq.to_sql
-      where("id IN (#{sql})")
+      where("vehicle_journeys.id IN (#{sql})")
     }
 
     # We need this for the ransack object in the filters


### PR DESCRIPTION
We were getting this errorwhen filtering by purchase window on the
`ReferentialVehicleJourneys#index` page.

An example of a filter query that triggered the error:
http://stif-boiv.dev:3000/referentials/4/vehicle_journeys?utf8=✓&q[published_journey_name_or_objectid_cont]=&q[company_id_eq_any][]=&q[route_line_id_eq]=&q[published_journey_name_gteq]=&q[published_journey_name_lteq]=&q[stop_area_ids][]=&q[purchase_window][start_date(3i)]=12&q[purchase_window][start_date(2i)]=1&q[purchase_window][start_date(1i)]=2018&q[purchase_window][end_date(3i)]=15&q[purchase_window][end_date(2i)]=1&q[purchase_window][end_date(1i)]=2019&q[time_table][start_date(3i)]=&q[time_table][start_date(2i)]=&q[time_table][start_date(1i)]=&q[time_table][end_date(3i)]=&q[time_table][end_date(2i)]=&q[time_table][end_date(1i)]=&commit=Filtrer

    ActiveRecord::StatementInvalid in ReferentialVehicleJourneys#index

    Showing stif-boiv/app/views/referential_vehicle_journeys/_filters.html.slim where line #24 raised:

    PG::AmbiguousColumn: ERROR:  column reference "id" is ambiguous
    LINE 1: ...RE "vehicle_journeys"."journey_category" = 0 AND (id IN (SEL...
                                                                 ^
    : SELECT "public"."lines".* FROM "public"."lines" WHERE (id IN (SELECT  routes.line_id FROM "vehicle_journeys" INNER JOIN "routes" ON "routes"."id" = "vehicle_journeys"."route_id" WHERE "vehicle_journeys"."journey_category" = 0 AND (id IN (SELECT DISTINCT vehicle_journeys.id FROM "purchase_windows" INNER JOIN "purchase_windows_vehicle_journeys" ON "purchase_windows_vehicle_journeys"."purchase_window_id" = "purchase_windows"."id" INNER JOIN "vehicle_journeys" ON "vehicle_journeys"."id" = "purchase_windows_vehicle_journeys"."vehicle_journey_id" AND "vehicle_journeys"."journey_category" = 0 WHERE (daterange('2018-01-12', '2019-01-16') && any (date_ranges))))  ORDER BY "vehicle_journeys"."published_journey_name" ASC LIMIT 10 OFFSET 0))

    Extracted source (around line #24):

              class: 'control-label'
          .form-inline.filter_menu
            = f.input :route_line_id_eq,
                as: :select,
                include_blank: t(".all"),
                collection: @vehicle_journeys.lines,

    Trace of template inclusion: app/views/referential_vehicle_journeys/index.html.slim

We're trying to match `VehicleJourney`s here, so qualify the `id` column
with the table name to fix the error.

Refs #5943