### PR TITLE
Refs #5927 @1h; Add a BOM at the beginning of CSVs

### DIFF
--- a/app/models/compliance_check_message_export.rb
+++ b/app/models/compliance_check_message_export.rb
@@ -26,12 +26,14 @@ class ComplianceCheckMessageExport
   end
 
   def to_csv(options = {})
-    CSV.generate(options.slice(:col_sep, :quote_char, :force_quotes)) do |csv|
+    csv_string = CSV.generate(options.slice(:col_sep, :quote_char, :force_quotes)) do |csv|
       csv << column_names
       compliance_check_messages.each do |compliance_check_message|
         csv << [compliance_check_message.compliance_check.criticity, *compliance_check_message.message_attributes.values_at('test_id', 'source_objectid'), options[:server_url] + compliance_check_message.message_attributes['source_object_path'], I18n.t("compliance_check_messages.#{compliance_check_message.message_key}", compliance_check_message.message_attributes.deep_symbolize_keys)]
       end
     end
+    # We add a BOM to indicate we use UTF-8
+    "\uFEFF" + csv_string
   end
 
   def to_zip(temp_file,options = {})


### PR DESCRIPTION
In the exported csv, add a BOM at the beginning to tell Excel we use
UTF-8

![capture d ecran 2018-02-23 09 51 30](https://user-images.githubusercontent.com/254393/36585679-23d31414-187f-11e8-9ab1-8fd43fa52e67.png)
