### PR TITLE
6404: RouteWayCostUnitConverter: Snap values between 0–1 to 1

### DIFF
--- a/lib/route_way_cost_unit_converter.rb
+++ b/lib/route_way_cost_unit_converter.rb
@@ -8,18 +8,24 @@ class RouteWayCostUnitConverter
     end
   end
 
-  private
-
   # Round to 2 decimal places to appease JavaScript validation
   def self.meters_to_kilometers(num)
     return 0 unless num
 
-    (num / 1000.0).to_i
+    snap_to_one(num / 1000.0).to_i
   end
 
   def self.seconds_to_minutes(num)
     return 0 unless num
 
-    num / 60
+    snap_to_one(num / 60.0).to_i
+  end
+
+  private
+
+  def self.snap_to_one(decimal)
+    return 1 if decimal > 0 && decimal <= 1
+
+    decimal
   end
 end

--- a/spec/lib/route_way_cost_unit_converter_spec.rb
+++ b/spec/lib/route_way_cost_unit_converter_spec.rb
@@ -35,4 +35,32 @@ RSpec.describe RouteWayCostUnitConverter do
       })
     end
   end
+
+  describe ".meters_to_kilometers" do
+    it "converts meters to integer kilometres" do
+      expect(
+        RouteWayCostUnitConverter.meters_to_kilometers(6350)
+      ).to eq(6)
+    end
+
+    it "snaps values between 0 and 1 to 1" do
+      expect(
+        RouteWayCostUnitConverter.meters_to_kilometers(50)
+      ).to eq(1)
+    end
+  end
+
+  describe ".seconds_to_minutes" do
+    it "converts seconds to minutes" do
+      expect(
+        RouteWayCostUnitConverter.seconds_to_minutes(300)
+      ).to eq(5)
+    end
+
+    it "snaps values between 0 and 1 to 1" do
+      expect(
+        RouteWayCostUnitConverter.seconds_to_minutes(3)
+      ).to eq(1)
+    end
+  end
 end


### PR DESCRIPTION
We use integer values for distance (kilometres) and time (minutes). If
the values aren't very big, like bus stops inside a city for example,
the integer conversion will put distance and time at `0`, which isn't
correct.

To continue to use our chosen measurement units while still displaying
something that makes sense to users, snap any values >0 and <=1 to `1`.

Refs #6404