### PR TITLE
6450 Don't consider the empty string as a valid color for Timetables

### DIFF
--- a/app/models/chouette/purchase_window.rb
+++ b/app/models/chouette/purchase_window.rb
@@ -46,8 +46,9 @@ module Chouette
       ]
     end
 
-    # def checksum_attributes
-    # end
-
+    def color
+      _color = read_attribute(:color)
+      _color.present? ? _color : nil
+    end
   end
 end

--- a/app/models/chouette/time_table.rb
+++ b/app/models/chouette/time_table.rb
@@ -81,6 +81,11 @@ module Chouette
       chunk.values.delete_if {|dates| dates.count < 2}
     end
 
+    def color
+      _color = read_attribute(:color)
+      _color.present? ? _color : nil
+    end
+
     def convert_continuous_dates_to_periods
       chunks = self.continuous_dates
 


### PR DESCRIPTION
Same for PurchaseWindows