### PR TITLE
6410 Route: Don't run `#calculate_costs!` during a referential merge

### DIFF
--- a/app/models/chouette/route.rb
+++ b/app/models/chouette/route.rb
@@ -80,7 +80,11 @@ module Chouette
     validates :wayback, inclusion: { in: self.wayback.values }
     after_commit :calculate_costs!,
       on: [:create, :update],
-      if: ->() { TomTom.enabled? }
+      if: ->() {
+        # Ensure the call back doesn't run during a referential merge
+        !referential.in_referential_suite? &&
+          TomTom.enabled?
+      }
 
     def duplicate opposite=false
       overrides = {

--- a/spec/models/chouette/route/route_base_spec.rb
+++ b/spec/models/chouette/route/route_base_spec.rb
@@ -77,5 +77,24 @@ RSpec.describe Chouette::Route, :type => :model do
       expect(route).not_to receive(:calculate_costs!)
       route.save
     end
+
+    it "doesn't call #calculate_costs! after_commit if in a ReferentialSuite",
+        truncation: true do
+      begin
+        allow(TomTom).to receive(:enabled?).and_return(true)
+
+        referential_suite = create(:referential_suite)
+        referential = create(:referential, referential_suite: referential_suite)
+
+        referential.switch do
+          route = build(:route)
+
+          expect(route).not_to receive(:calculate_costs!)
+          route.save
+        end
+      ensure
+        referential.destroy
+      end
+    end
   end
 end


### PR DESCRIPTION
Dans un merge, il ne faut pas qu'une `Chouette::Route` lance `#calculate_costs!`. On peut utiliser `Referential#in_referential_suite?` pour vérifier qu'on n'est pas dans une procédure de merge.