### PR TITLE
6377 Make lines/stops associations with workbenches configurable

### DIFF
--- a/app/controllers/referentials_controller.rb
+++ b/app/controllers/referentials_controller.rb
@@ -142,7 +142,7 @@ class ReferentialsController < ChouetteController
   def build_referential
     if params[:from]
       source_referential = Referential.find(params[:from])
-      @referential = Referential.new_from(source_referential, current_organisation)
+      @referential = Referential.new_from(source_referential, current_workbench)
     end
 
     @referential.data_format = current_organisation.data_format

--- a/app/models/merge.rb
+++ b/app/models/merge.rb
@@ -98,7 +98,7 @@ class Merge < ApplicationModel
     new =
       if workbench.output.current
         Rails.logger.debug "Clone current output"
-        Referential.new_from(workbench.output.current, workbench.organisation).tap do |clone|
+        Referential.new_from(workbench.output.current, workbench).tap do |clone|
           clone.inline_clone = true
         end
       else

--- a/app/models/referential.rb
+++ b/app/models/referential.rb
@@ -258,7 +258,7 @@ class Referential < ApplicationModel
     end
   end
 
-  def self.new_from(from, organisation)
+  def self.new_from(from, workbench)
     Referential.new(
       name: I18n.t("activerecord.copy", name: from.name),
       prefix: from.prefix,
@@ -268,7 +268,7 @@ class Referential < ApplicationModel
       stop_area_referential: from.stop_area_referential,
       created_from: from,
       objectid_format: from.objectid_format,
-      metadatas: from.metadatas.map { |m| ReferentialMetadata.new_from(m, organisation) },
+      metadatas: from.metadatas.map { |m| ReferentialMetadata.new_from(m, workbench) },
       ready: false
     )
   end

--- a/app/models/referential_metadata.rb
+++ b/app/models/referential_metadata.rb
@@ -155,10 +155,10 @@ class ReferentialMetadata < ApplicationModel
   end
   private :clear_periods
 
-  def self.new_from(from, organisation)
+  def self.new_from(from, workbench)
     from.dup.tap do |metadata|
       metadata.referential_source_id = from.referential_id
-      metadata.line_ids = from.referential.lines.where(id: metadata.line_ids).for_organisation(organisation).pluck(:id)
+      metadata.line_ids = workbench.lines.where(id: metadata.line_ids).pluck(:id)
       metadata.referential_id = nil
     end
   end

--- a/app/models/workbench.rb
+++ b/app/models/workbench.rb
@@ -8,11 +8,11 @@ class Workbench < ApplicationModel
   belongs_to :output, class_name: 'ReferentialSuite'
   belongs_to :workgroup
 
-  has_many :lines, -> (workbench) { Stif::MyWorkbenchScopes.new(workbench).line_scope(self) }, through: :line_referential
+  has_many :lines, -> (workbench) { workbench.workbench_scopes.lines_scope(self) }, through: :line_referential
+  has_many :stop_areas, -> (workbench) { workbench.workbench_scopes.stop_areas_scope(self) }, through: :stop_area_referential
   has_many :networks, through: :line_referential
   has_many :companies, through: :line_referential
   has_many :group_of_lines, through: :line_referential
-  has_many :stop_areas, through: :stop_area_referential
   has_many :imports, class_name: Import::Base
   has_many :exports, class_name: Export::Base
   has_many :workbench_imports, class_name: Import::Workbench
@@ -29,6 +29,9 @@ class Workbench < ApplicationModel
 
   before_validation :initialize_output
 
+  def workbench_scopes
+    workgroup.workbench_scopes(self)
+  end
 
   def all_referentials
     if line_ids.empty?

--- a/app/models/workgroup.rb
+++ b/app/models/workgroup.rb
@@ -61,6 +61,10 @@ class Workgroup < ApplicationModel
     compliance_control_sets_labels all_compliance_control_sets.grep(/^after_merge/)
   end
 
+  def workbench_scopes workbench
+    self.class.workbench_scopes_class.new(workbench)
+  end
+
   private
   def compliance_control_sets_labels(keys)
     keys.inject({}) do |h, k|
@@ -69,7 +73,4 @@ class Workgroup < ApplicationModel
     end
   end
 
-  def workbench_scopes workbench
-    self.class.workbench_scopes_class.new(workbench)
-  end
 end

--- a/app/models/workgroup.rb
+++ b/app/models/workgroup.rb
@@ -19,6 +19,9 @@ class Workgroup < ApplicationModel
 
   accepts_nested_attributes_for :workbenches
 
+  @@workbench_scopes_class = Stif::WorkbenchScopes
+  mattr_accessor :workbench_scopes_class
+
   def custom_fields_definitions
     Hash[*custom_fields.map{|cf| [cf.code, cf]}.flatten]
   end
@@ -64,5 +67,9 @@ class Workgroup < ApplicationModel
       h[k] = "workgroups.compliance_control_sets.#{k}".t.capitalize
       h
     end
+  end
+
+  def workbench_scopes workbench
+    self.class.workbench_scopes_class.new(workbench)
   end
 end

--- a/app/views/referentials/_form.html.slim
+++ b/app/views/referentials/_form.html.slim
@@ -49,7 +49,7 @@
     .separator
     .row
       .col-lg-11
-        = subform.input :lines, as: :select, collection: Chouette::Line.includes(:company).order(:name).for_organisation(current_organisation).for_workbench(@workbench), selected: subform.object.line_ids, label_method: :display_name, input_html: { 'data-select2ed': 'true', 'data-select2ed-placeholder': t('simple_form.labels.referential.placeholders.select_lines'), 'multiple': 'multiple', style: 'width: 100%' }
+        = subform.input :lines, as: :select, collection: @workbench.lines, selected: subform.object.line_ids, label_method: :display_name, input_html: { 'data-select2ed': 'true', 'data-select2ed-placeholder': t('simple_form.labels.referential.placeholders.select_lines'), 'multiple': 'multiple', style: 'width: 100%' }
       .col-lg-1
         a.clear-lines.btn.btn-default href='#'
           .fa.fa-trash

--- a/lib/stif/workbench_scopes.rb
+++ b/lib/stif/workbench_scopes.rb
@@ -1,23 +1,19 @@
 module Stif
-  class MyWorkbenchScopes
-    attr_accessor :workbench
+  class WorkbenchScopes < ::WorkbenchScopes::All
 
-    
-    def initialize(workbench)
-      @workbench = workbench
-    end
-
-    def line_scope(initial_scope)
+    def lines_scope(initial_scope)
       ids = parse_functional_scope
       ids ? initial_scope.where(objectid: ids) : initial_scope
     end
+
+    protected
 
     def parse_functional_scope
       return false unless @workbench.organisation.sso_attributes
       begin
         JSON.parse @workbench.organisation.sso_attributes['functional_scope']
       rescue Exception => e
-        Rails.logger.error "MyWorkbenchScopes : #{e}"
+        Rails.logger.error "WorkbenchScopes : #{e}"
       end
     end
   end

--- a/lib/workbench_scopes/all.rb
+++ b/lib/workbench_scopes/all.rb
@@ -1,0 +1,17 @@
+module WorkbenchScopes
+  class All
+    attr_accessor :workbench
+
+    def initialize(workbench)
+      @workbench = workbench
+    end
+
+    def lines_scope(initial_scope)
+      initial_scope
+    end
+
+    def stop_areas_scope(initial_scope)
+      initial_scope
+    end
+  end
+end

--- a/spec/models/referential/referential_oid_format_from_wkbch_spec.rb
+++ b/spec/models/referential/referential_oid_format_from_wkbch_spec.rb
@@ -44,8 +44,7 @@ RSpec.describe Referential do
 
   describe 'self.new_from' do
 
-    let( :source ){ build :referential }
-    let( :functional_scope ){ double('functional scope') }
+    let( :source ){ build :workbench_referential }
 
     it 'copies objectid_format from source' do
       expect( described_class )
@@ -61,7 +60,7 @@ RSpec.describe Referential do
       metadatas: source.metadatas.map { |m| ReferentialMetadata.new_from(m, functional_scope) },
       ready: false)
 
-      described_class.new_from( source, functional_scope )
+      described_class.new_from( source, source.workbench )
     end
 
   end

--- a/spec/models/referential_spec.rb
+++ b/spec/models/referential_spec.rb
@@ -195,7 +195,7 @@ describe Referential, :type => :model do
 
   context "Cloning referential" do
     let(:clone) do
-      Referential.new_from(ref, nil)
+      Referential.new_from(ref, ref.workbench)
     end
 
     let!(:workbench){ create :workbench }


### PR DESCRIPTION
You can now define a `Workgroup.workbench_scopes_class` which will deal
with the association between a workbench and its lines and stops