### PR TITLE
5372 Use referential metadata in the cleanup operation

### DIFF
--- a/app/models/referential_cloning.rb
+++ b/app/models/referential_cloning.rb
@@ -25,6 +25,8 @@ class ReferentialCloning < ApplicationModel
         .clone_schema
     end
     target_referential.check_migration_count(report)
+
+    CleanUp.new(referential: target_referential).clean
   end
 
   private


### PR DESCRIPTION
Use referential metadata to clean routes. 
Restore 'data' clean (vehicle_journey/journey_pattern/route). 
Make date_type/begin_date/end_date optionnal for internal usage. Refs #