### PR TITLE
Refs #6486; Change the `font-display` property

### DIFF
--- a/app/assets/stylesheets/_layout.sass
+++ b/app/assets/stylesheets/_layout.sass
@@ -15,6 +15,7 @@ body
   line-height: $line-height
   color: $darkgrey
   background-color: #fff
+  font-display: block
 
 .page_header
   padding: 40px 35px 0 35px


### PR DESCRIPTION
Force the browser to wait for the fonts to be loaded, to prevent a wrong
cells size calculation by the JS.