### PR TITLE
6661-make-TomTom-data-more-consistent

### DIFF
--- a/lib/tom_tom/matrix.rb
+++ b/lib/tom_tom/matrix.rb
@@ -15,6 +15,7 @@ module TomTom
         req.headers['Content-Type'] = 'application/json'
 
         req.params[:routeType] = 'shortest'
+        req.params[:traffic] = 'false'
         req.params[:travelMode] = 'bus'
 
         req.body = build_request_body(points)


### PR DESCRIPTION
Désactive le calcul avec "traffic" dans TomTom (qui est activé par défaut https://developer.tomtom.com/online-routing/online-routing-documentation-routing/common-routing-parameters) pour éviter que les temps de trajet soient radicalement différents entre les mêmes arrêts quand le calcul est effectué à différents moments.