### PR TITLE
6858: Workbenches#show: Don't allow pending referentials to be selected

### DIFF
--- a/app/views/workbenches/show.html.slim
+++ b/app/views/workbenches/show.html.slim
@@ -62,7 +62,10 @@
                   attribute: Proc.new {|w| w.merged_at ? l(w.merged_at, format: :short) : '-'} \
                 ) \
               ],
-              selectable: ->(ref){ @workbench.referentials.include?(ref) },
+              selectable: ->(ref) { \
+                @workbench.referentials.include?(ref) && \
+                  !ref.pending? \
+              },
               cls: 'table has-filter has-search',
               action: :index
 

--- a/spec/features/workbenches/workbenches_show_spec.rb
+++ b/spec/features/workbenches/workbenches_show_spec.rb
@@ -64,6 +64,27 @@ RSpec.describe 'Workbenches', type: :feature do
         "Couldn't find `hidden_referential`: `#{hidden_referential.inspect}`"
     end
 
+    it "prevents pending referentials from being selected" do
+      line = create(:line, line_referential: line_ref)
+      metadata = create(:referential_metadata, lines: [line])
+      pending_referential = create(
+        :workbench_referential,
+        workbench: workbench,
+        metadatas: [metadata],
+        organisation: @user.organisation,
+        ready: false
+      )
+
+      visit workbench_path(workbench)
+
+      expect(
+        find("input[type='checkbox'][value='#{referential.id}']")
+      ).not_to be_disabled
+      expect(
+        find("input[type='checkbox'][value='#{pending_referential.id}']")
+      ).to be_disabled
+    end
+
     context 'filtering' do
       let!(:another_organisation) { create :organisation }
       let(:another_line) { create :line, line_referential: line_ref }


### PR DESCRIPTION
Désactive les checkboxes pour les `Referential`s en état `pending`. Ceci permet de refuser la suppression de `Referential`s pending en batch.

![screen shot 2018-04-30 at 5 22 21 pm](https://user-images.githubusercontent.com/342964/39435220-1420a1da-4c9b-11e8-8d2d-5938808fad11.png)
