### PR TITLE
6952 waycost  costs under 500m birds eye distance should sna

### DIFF
--- a/app/services/route_way_cost_calculator.rb
+++ b/app/services/route_way_cost_calculator.rb
@@ -6,6 +6,7 @@ class RouteWayCostCalculator
   def calculate!
     way_costs = StopAreasToWayCostsConverter.new(@route.stop_areas).convert
     way_costs = TomTom.matrix(way_costs)
+    way_costs = WayCostMinimumDistance.new(way_costs).snap_short_costs_to_1
     way_costs = WayCostCollectionJSONSerializer.dump(way_costs)
     @route.update(costs: way_costs)
   end

--- a/lib/rgeo_ext.rb
+++ b/lib/rgeo_ext.rb
@@ -1,0 +1,10 @@
+module RGeoExt
+  def self.geographic_factory
+    @@geographic_factory ||= RGeo::Geographic.spherical_factory(
+      wkt_parser: { support_ewkt: true, default_srid: 4326 },
+      wkt_generator: { type_format: :ewkt, emit_ewkt_srid: true },
+      wkb_parser: { support_ewkb: true, default_srid: 4326 },
+      wkb_generator: { type_format: :ewkb, emit_ewkb_srid: true }
+    )
+  end
+end

--- a/lib/route_way_cost_unit_converter.rb
+++ b/lib/route_way_cost_unit_converter.rb
@@ -8,7 +8,6 @@ class RouteWayCostUnitConverter
     end
   end
 
-  # Round to 2 decimal places to appease JavaScript validation
   def self.meters_to_kilometers(num)
     return 0 unless num
 

--- a/lib/way_cost.rb
+++ b/lib/way_cost.rb
@@ -28,9 +28,7 @@ class WayCost
   end
 
   def calculate_distance
-    departure = RGeoExt.geographic_factory.point(@departure.lng, @departure.lat)
-    arrival = RGeoExt.geographic_factory.point(@arrival.lng, @arrival.lat)
-
-    departure.distance(arrival)
+    distance_meters = departure.distance_to(arrival, units: :kms) * 1000
+    distance_meters
   end
 end

--- a/lib/way_cost.rb
+++ b/lib/way_cost.rb
@@ -1,3 +1,5 @@
+require 'rgeo_ext'
+
 class WayCost
   attr_reader :departure, :arrival, :id
   attr_accessor :distance, :time
@@ -23,5 +25,12 @@ class WayCost
       @distance == other.distance &&
       @time == other.time &&
       @id == other.id
+  end
+
+  def calculate_distance
+    departure = RGeoExt.geographic_factory.point(@departure.lng, @departure.lat)
+    arrival = RGeoExt.geographic_factory.point(@arrival.lng, @arrival.lat)
+
+    departure.distance(arrival)
   end
 end

--- a/lib/way_cost_minimum_distance.rb
+++ b/lib/way_cost_minimum_distance.rb
@@ -1,6 +1,7 @@
 class WayCostMinimumDistance
   MINIMUM_DISTANCE_METERS = 500
   SNAP_TO_METERS = 1000
+  SNAP_TO_SECONDS = 60
 
   def initialize(way_costs)
     @way_costs = way_costs
@@ -12,6 +13,7 @@ class WayCostMinimumDistance
 
       if distance < MINIMUM_DISTANCE_METERS
         way_cost.distance = SNAP_TO_METERS
+        way_cost.time = SNAP_TO_SECONDS
       end
 
       way_cost

--- a/lib/way_cost_minimum_distance.rb
+++ b/lib/way_cost_minimum_distance.rb
@@ -1,0 +1,20 @@
+class WayCostMinimumDistance
+  MINIMUM_DISTANCE_METERS = 500
+  SNAP_TO_METERS = 1000
+
+  def initialize(way_costs)
+    @way_costs = way_costs
+  end
+
+  def snap_short_costs_to_1
+    @way_costs.map do |way_cost|
+      distance = way_cost.calculate_distance
+
+      if distance < MINIMUM_DISTANCE_METERS
+        way_cost.distance = SNAP_TO_METERS
+      end
+
+      way_cost
+    end
+  end
+end

--- a/spec/lib/way_cost_minimum_distance_spec.rb
+++ b/spec/lib/way_cost_minimum_distance_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe WayCostMinimumDistance do
   describe "#snap_short_costs_to_1" do
-    it "snaps distances under 500 metres to 1 kilometre" do
-      way_costs = [
+    let(:way_costs) do
+      [
         # Paris–Bordeaux
         WayCost.new(
           departure: Geokit::LatLng.new(2.349, 48.85331),
@@ -14,13 +14,24 @@ RSpec.describe WayCostMinimumDistance do
           arrival: Geokit::LatLng.new(2.35, 48.8701)
         )
       ]
+    end
 
+    it "snaps distances under 500 metres to 1 kilometre" do
       unchanged, snapped = WayCostMinimumDistance.new(
         way_costs
       ).snap_short_costs_to_1
 
       expect(unchanged.distance).to eq(way_costs[0].distance)
       expect(snapped.distance).to eq(1000)
+    end
+
+    it "snaps time to 1 minute when distance is under 500 metres" do
+      unchanged, snapped = WayCostMinimumDistance.new(
+        way_costs
+      ).snap_short_costs_to_1
+
+      expect(unchanged.time).to eq(way_costs[0].time)
+      expect(snapped.time).to eq(60)
     end
   end
 end

--- a/spec/lib/way_cost_minimum_distance_spec.rb
+++ b/spec/lib/way_cost_minimum_distance_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe WayCostMinimumDistance do
+  describe "#snap_short_costs_to_1" do
+    it "snaps distances under 500 metres to 1 kilometre" do
+      way_costs = [
+        # Paris–Bordeaux
+        WayCost.new(
+          departure: Geokit::LatLng.new(2.349, 48.85331),
+          arrival: Geokit::LatLng.new(-0.57628, 44.84452)
+        ),
+
+        # Rue Poissonnière–Boulevard de Bonne Nouvelle
+        WayCost.new(
+          departure: Geokit::LatLng.new(2.34776, 48.86927),
+          arrival: Geokit::LatLng.new(2.35, 48.8701)
+        )
+      ]
+
+      unchanged, snapped = WayCostMinimumDistance.new(
+        way_costs
+      ).snap_short_costs_to_1
+
+      expect(unchanged.distance).to eq(way_costs[0].distance)
+      expect(snapped.distance).to eq(1000)
+    end
+  end
+end

--- a/spec/lib/way_cost_spec.rb
+++ b/spec/lib/way_cost_spec.rb
@@ -9,10 +9,9 @@ RSpec.describe WayCost do
         id: '1-2'
       )
 
-      departure = RGeoExt.geographic_factory.point(2.36143, 48.85086)
-      arrival = RGeoExt.geographic_factory.point(1.87606, 47.91231)
-
-      expect(way_cost.calculate_distance).to eq(departure.distance(arrival))
+      expect(way_cost.calculate_distance).to eq(
+        way_cost.departure.distance_to(way_cost.arrival, units: :kms) * 1000
+      )
     end
   end
 end

--- a/spec/lib/way_cost_spec.rb
+++ b/spec/lib/way_cost_spec.rb
@@ -1,0 +1,18 @@
+RSpec.describe WayCost do
+  describe "#calculate_distance" do
+    it "calculates the distance between departure and arrival" do
+      way_cost = WayCost.new(
+        departure: Geokit::LatLng.new(48.85086, 2.36143),
+        arrival: Geokit::LatLng.new(47.91231, 1.87606),
+        distance: 1234,
+        time: 99,
+        id: '1-2'
+      )
+
+      departure = RGeoExt.geographic_factory.point(2.36143, 48.85086)
+      arrival = RGeoExt.geographic_factory.point(1.87606, 47.91231)
+
+      expect(way_cost.calculate_distance).to eq(departure.distance(arrival))
+    end
+  end
+end


### PR DESCRIPTION
After calculating `WayCost`s from TomTom, calculate the “crow flies” distance of those costs. If the “crow flies” distance is under 500 metres, distance should be snapped to 1 kilometre and time should be snapped to 1 minute.

We do this to get around a TomTom edge case. For example: Two `StopArea`s are on opposite sides of a highway. When TomTom is asked for the distance & time between them, it follows the road. This means the cost includes the ride to an offramp, crossing the highway, and driving back to the `StopArea` on the other side.

In that case, we don't care about the extra driving cost, only the actual physical distance between the `StopArea`s.