### PR TITLE
Refs #6955 Add new translation + custom delete confirmation modal

### DIFF
--- a/app/assets/javascripts/modal_confirmation.js
+++ b/app/assets/javascripts/modal_confirmation.js
@@ -1,0 +1,31 @@
+$(document).ready(() => {
+  $.rails.allowAction = (link) => {
+    let message = link.data('confirm')
+    if (!message) return true
+    showConfirmModal(link)
+    return false
+  }
+
+  let showConfirmModal = (link) => {
+    let message = link.data('confirm')
+    let html = `<div class="modal fade" id="confirmationDialog" tabindex="1" role="dialog">
+        <div class="modal-container">
+          <div class="modal-dialog">
+            <div class="modal-content">
+              <div class="modal-header">
+                <h4 class="modal-title"> ${I18n.t('warning')} </h4>
+              </div>
+              <div class="modal-body">
+                <p>${message}</p>
+              </div>
+              <div class="modal-footer">
+                <a data-dismiss="modal" class="btn">${I18n.t('cancel')}</a>
+                <a data-dismiss="modal" class="btn btn-primary" data-method=${link.data('method')} href=${link.attr('href')}>${I18n.t('ok')}</a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div> `
+    $(html).modal()
+  }
+})

--- a/app/decorators/compliance_control_decorator.rb
+++ b/app/decorators/compliance_control_decorator.rb
@@ -5,7 +5,7 @@ class ComplianceControlDecorator < AF83::Decorator
 
   with_instance_decorator do |instance_decorator|
     instance_decorator.show_action_link do |l|
-      l.content h.t('compliance_control_sets.actions.show')
+      l.content t('compliance_control_sets.actions.show')
       l.href do
         h.compliance_control_set_compliance_control_path(
           object.compliance_control_set.id,
@@ -17,7 +17,7 @@ class ComplianceControlDecorator < AF83::Decorator
     instance_decorator.edit_action_link
 
     instance_decorator.destroy_action_link do |l|
-      l.data confirm: h.t('compliance_controls.actions.destroy_confirm')
+      l.data confirm: t('compliance_controls.actions.destroy_confirm')
     end
   end
 

--- a/app/decorators/compliance_control_set_decorator.rb
+++ b/app/decorators/compliance_control_set_decorator.rb
@@ -20,7 +20,7 @@ class ComplianceControlSetDecorator < AF83::Decorator
     instance_decorator.destroy_action_link do |l|
       l.content h.destroy_link_content
       l.href { h.compliance_control_set_path(object.id) }
-      l.data confirm: h.t('compliance_control_sets.actions.destroy_confirm')
+      l.data confirm: t('compliance_control_sets.actions.destroy_confirm')
     end
   end
 end

--- a/app/decorators/line_decorator.rb
+++ b/app/decorators/line_decorator.rb
@@ -44,7 +44,7 @@ class LineDecorator < AF83::Decorator
       l.content  { h.deactivate_link_content('lines.actions.deactivate') }
       l.href     { h.deactivate_line_referential_line_path(context[:line_referential], object) }
       l.method   :put
-      l.data     confirm: h.t('lines.actions.deactivate_confirm')
+      l.data     {{ confirm: h.t('lines.actions.deactivate_confirm') }}
       l.add_class "delete-action"
     end
 
@@ -52,13 +52,13 @@ class LineDecorator < AF83::Decorator
       l.content  { h.activate_link_content('lines.actions.activate') }
       l.href     { h.activate_line_referential_line_path(context[:line_referential], object) }
       l.method   :put
-      l.data     confirm: h.t('lines.actions.activate_confirm')
+      l.data     {{ confirm: h.t('lines.actions.activate_confirm') }}
       l.add_class "delete-action"
     end
 
     instance_decorator.destroy_action_link do |l|
       l.content  { h.destroy_link_content('lines.actions.destroy') }
-      l.data     confirm: h.t('lines.actions.destroy_confirm')
+      l.data     {{ confirm: h.t('lines.actions.destroy_confirm') }}
       l.add_class "delete-action"
     end
   end

--- a/app/decorators/network_decorator.rb
+++ b/app/decorators/network_decorator.rb
@@ -25,8 +25,8 @@ class NetworkDecorator < AF83::Decorator
     end
 
     instance_decorator.destroy_action_link do |l|
-      l.content h.t('networks.actions.destroy')
-      l.data confirm: h.t('networks.actions.destroy_confirm')
+      l.content { h.destroy_link_content('networks.actions.destroy') }
+      l.data {{ confirm: h.t('networks.actions.destroy_confirm') }}
     end
   end
 end

--- a/app/decorators/network_decorator.rb
+++ b/app/decorators/network_decorator.rb
@@ -25,7 +25,7 @@ class NetworkDecorator < AF83::Decorator
     end
 
     instance_decorator.destroy_action_link do |l|
-      l.content h.destroy_link_content('networks.actions.destroy')
+      l.content h.t('networks.actions.destroy')
       l.data confirm: h.t('networks.actions.destroy_confirm')
     end
   end

--- a/app/decorators/purchase_window_decorator.rb
+++ b/app/decorators/purchase_window_decorator.rb
@@ -15,7 +15,7 @@ class PurchaseWindowDecorator < AF83::Decorator
     instance_decorator.edit_action_link
 
     instance_decorator.destroy_action_link do |l|
-      l.data confirm: h.t('purchase_windows.actions.destroy_confirm')
+      l.data confirm: t('purchase_windows.actions.destroy_confirm')
     end
   end
 

--- a/app/decorators/referential_line_decorator.rb
+++ b/app/decorators/referential_line_decorator.rb
@@ -18,7 +18,7 @@ class ReferentialLineDecorator < AF83::Decorator
     end
 
     instance_decorator.action_link secondary: true do |l|
-      l.content h.t('routing_constraint_zones.index.title')
+      l.content t('routing_constraint_zones.index.title')
       l.href do
         h.referential_line_routing_constraint_zones_path(
           scope,
@@ -36,7 +36,7 @@ class ReferentialLineDecorator < AF83::Decorator
       },
       secondary: true
     ) do |l|
-      l.content h.t('routes.actions.new')
+      l.content t('routes.actions.new')
       l.href { h.new_referential_line_route_path(scope, object) }
     end
   end

--- a/app/decorators/referential_line_decorator.rb
+++ b/app/decorators/referential_line_decorator.rb
@@ -13,7 +13,7 @@ class ReferentialLineDecorator < AF83::Decorator
     instance_decorator.show_action_link
 
     instance_decorator.action_link secondary: true do |l|
-      l.content Chouette::Line.human_attribute_name(:footnotes)
+      l.content Chouette::Line.tmf(:footnotes)
       l.href { h.referential_line_footnotes_path(context[:referential], object) }
     end
 

--- a/app/decorators/referential_network_decorator.rb
+++ b/app/decorators/referential_network_decorator.rb
@@ -20,8 +20,8 @@ class ReferentialNetworkDecorator < AF83::Decorator
     end
 
     instance_decorator.destroy_action_link do |l|
-      l.content h.destroy_link_content('networks.actions.destroy')
-      l.data confirm: h.t('networks.actions.destroy_confirm')
+      l.content { h.destroy_link_content('networks.actions.destroy') }
+      l.data confirm: t('networks.actions.destroy_confirm')
     end
   end
 end

--- a/app/decorators/route_decorator.rb
+++ b/app/decorators/route_decorator.rb
@@ -18,7 +18,7 @@ class RouteDecorator < AF83::Decorator
       if: ->() { object.stop_points.any? },
       secondary: :show
     ) do |l|
-      l.content h.t('journey_patterns.actions.index')
+      l.content t('journey_patterns.actions.index')
       l.href do
         [
           context[:referential],
@@ -33,7 +33,7 @@ class RouteDecorator < AF83::Decorator
       if: ->() { object.journey_patterns.present? },
       secondary: :show
     ) do |l|
-      l.content h.t('vehicle_journeys.actions.index')
+      l.content t('vehicle_journeys.actions.index')
       l.href do
         [
           context[:referential],
@@ -45,7 +45,7 @@ class RouteDecorator < AF83::Decorator
     end
 
     instance_decorator.action_link secondary: :show do |l|
-      l.content h.t('vehicle_journey_exports.new.title')
+      l.content t('vehicle_journey_exports.new.title')
       l.href do
         h.referential_line_route_vehicle_journey_exports_path(
           context[:referential],
@@ -60,7 +60,7 @@ class RouteDecorator < AF83::Decorator
       secondary: :show,
       policy: :duplicate
     ) do |l|
-      l.content h.t('routes.duplicate.title')
+      l.content t('routes.duplicate.title')
       l.method :post
       l.href do
         h.duplicate_referential_line_route_path(
@@ -76,7 +76,7 @@ class RouteDecorator < AF83::Decorator
       policy: :create_opposite,
       if: ->{h.has_feature?(:create_opposite_routes)}
     ) do |l|
-      l.content h.t('routes.create_opposite.title')
+      l.content t('routes.create_opposite.title')
       l.method :post
       l.disabled { object.opposite_route.present? }
       l.href do
@@ -90,7 +90,7 @@ class RouteDecorator < AF83::Decorator
     end
 
     instance_decorator.destroy_action_link do |l|
-      l.data confirm: h.t('routes.actions.destroy_confirm')
+      l.data confirm: t('routes.actions.destroy_confirm')
     end
   end
 end

--- a/app/decorators/routing_constraint_zone_decorator.rb
+++ b/app/decorators/routing_constraint_zone_decorator.rb
@@ -21,7 +21,7 @@ class RoutingConstraintZoneDecorator < AF83::Decorator
     instance_decorator.edit_action_link
 
     instance_decorator.destroy_action_link do |l|
-      l.data confirm: h.t('routing_constraint_zones.actions.destroy_confirm')
+      l.data confirm: t('routing_constraint_zones.actions.destroy_confirm')
     end
   end
 end

--- a/app/decorators/stop_area_decorator.rb
+++ b/app/decorators/stop_area_decorator.rb
@@ -11,11 +11,11 @@ class StopAreaDecorator < AF83::Decorator
     instance_decorator.show_action_link
 
     instance_decorator.edit_action_link do |l|
-      l.content h.t('stop_areas.actions.edit')
+      l.content t('stop_areas.actions.edit')
     end
 
     instance_decorator.action_link policy: :deactivate, secondary: true do |l|
-      l.content h.deactivate_link_content('stop_areas.actions.deactivate')
+      l.content { h.deactivate_link_content('stop_areas.actions.deactivate') }
       l.href do
         h.deactivate_stop_area_referential_stop_area_path(
           object.stop_area_referential,
@@ -23,12 +23,12 @@ class StopAreaDecorator < AF83::Decorator
         )
       end
       l.method :put
-      l.data confirm: h.t('stop_areas.actions.deactivate_confirm')
+      l.data confirm: t('stop_areas.actions.deactivate_confirm')
       l.add_class 'delete-action'
     end
 
     instance_decorator.action_link policy: :activate, secondary: true do |l|
-      l.content h.activate_link_content('stop_areas.actions.activate')
+      l.content { h.activate_link_content('stop_areas.actions.activate') }
       l.href do
         h.activate_stop_area_referential_stop_area_path(
           object.stop_area_referential,
@@ -36,13 +36,13 @@ class StopAreaDecorator < AF83::Decorator
         )
       end
       l.method :put
-      l.data confirm: h.t('stop_areas.actions.activate_confirm')
+      l.data confirm: t('stop_areas.actions.activate_confirm')
       l.add_class 'delete-action'
     end
 
     instance_decorator.destroy_action_link do |l|
-      l.content h.destroy_link_content('stop_areas.actions.destroy')
-      l.data confirm: h.t('stop_areas.actions.destroy_confirm')
+      l.content { h.destroy_link_content('stop_areas.actions.destroy') }
+      l.data confirm: t('stop_areas.actions.destroy_confirm')
     end
   end
 

--- a/app/decorators/stop_area_referential_decorator.rb
+++ b/app/decorators/stop_area_referential_decorator.rb
@@ -5,9 +5,9 @@ class StopAreaReferentialDecorator < AF83::Decorator
 
     instance_decorator.action_link policy: :synchronize, primary: :show do |l|
       l.content t('actions.sync')
-      l.href { h. sync_stop_area_referential_path(object.id) }
+      l.href { h.sync_stop_area_referential_path(object.id) }
       l.method :post
     end
-    
+
   end
 end

--- a/app/javascript/vehicle_journeys/actions/index.js
+++ b/app/javascript/vehicle_journeys/actions/index.js
@@ -379,11 +379,11 @@ const actions = {
                 vehicle_journey_at_stops: vjasWithDelta,
                 deletable: false,
                 selected: false,
-                published_journey_name: val.published_journey_name || 'non renseigné',
-                published_journey_identifier: val.published_journey_identifier || 'non renseigné',
-                company: val.company || {name: 'non renseigné'},
-                transport_mode: val.route.line.transport_mode || 'undefined',
-                transport_submode: val.route.line.transport_submode || 'undefined'
+                published_journey_name: val.published_journey_name || '',
+                published_journey_identifier: val.published_journey_identifier || '',
+                company: val.company || {name: ''},
+                transport_mode: val.route.line.transport_mode || '',
+                transport_submode: val.route.line.transport_submode || ''
               })
             )
           }

--- a/app/views/lines/_form.html.slim
+++ b/app/views/lines/_form.html.slim
@@ -4,7 +4,7 @@
       = f.input :name
       = f.input :network_id, as: :select, :collection => @line_referential.networks, include_blank: false
       = f.input :company_id, as: :select, :collection => @line_referential.companies, include_blank: true
-      = f.input :secondary_company_ids, :collection => @line_referential.companies, include_blank: false, input_html: { multiple: true, 'data-select2ed': true }, label: t('activerecord.attributes.line.secondary_company')
+      = f.input :secondary_company_ids, :collection => @line_referential.companies, include_blank: false, input_html: { multiple: true, 'data-select2ed': true }, label: Chouette::Line.tmf(:secondary_companies)
       = f.input :published_name
       = f.input :registration_number
       = f.input :number

--- a/app/views/routing_constraint_zones/show.html.slim
+++ b/app/views/routing_constraint_zones/show.html.slim
@@ -16,15 +16,15 @@
         = table_builder_2 @routing_constraint_zone.route.stop_points,
           [ \
             TableBuilderHelper::Column.new( \
-              name: "Arrêts de l'itinéraire", \
+              name: t('.route_stop_points'), \
               attribute: 'name', \
               link_to: lambda do |stop_point| \
                 referential_stop_area_path(@referential, stop_point.stop_area) \
               end \
             ),
             TableBuilderHelper::Column.new( \
-              name: "Arrêts inclus dans l'ITL", \
-              attribute: Proc.new{ |rsp| (@routing_constraint_zone.stop_point_ids.include? rsp.id) ? 'Oui' : 'Non' } \
+              name: t('.stop_points'), \
+              attribute: Proc.new{ |rsp| (@routing_constraint_zone.stop_point_ids.include? rsp.id) ? t('yes') : t('no') } \
             ) \
           ],
           sortable: false,

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -3,7 +3,7 @@ crumb :root do
 end
 
 crumb :workbench do |workbench|
-  link workbench.name, workbench_path(workbench)
+  link I18n.t('workbenches.index.offers.title'), workbench_path(workbench)
 end
 
 crumb :workbench_output do |workbench|
@@ -160,7 +160,6 @@ end
 
 crumb :stop_areas do |stop_area_referential|
   link I18n.t('stop_areas.index.title'), stop_area_referential_stop_areas_path(stop_area_referential)
-  parent :stop_area_referential, stop_area_referential
 end
 
 crumb :stop_area do |stop_area_referential, stop_area|

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -3,7 +3,7 @@ crumb :root do
 end
 
 crumb :workbench do |workbench|
-  link I18n.t('workbenches.index.offers.title'), workbench_path(workbench)
+  link workbench.name, workbench_path(workbench)
 end
 
 crumb :workbench_output do |workbench|

--- a/config/locales/actions.en.yml
+++ b/config/locales/actions.en.yml
@@ -35,3 +35,4 @@ en:
   no_result_text: "No Results"
   searching_term: "Searching..."
   are_you_sure: Are you sure?
+  ok: Ok

--- a/config/locales/actions.fr.yml
+++ b/config/locales/actions.fr.yml
@@ -35,3 +35,4 @@ fr:
   no_result_text: "Aucun résultat"
   searching_term: "Recherche en cours..."
   are_you_sure: Etes vous sûr ?
+  ok: Ok

--- a/config/locales/companies.en.yml
+++ b/config/locales/companies.en.yml
@@ -6,7 +6,7 @@ en:
       new: "Add a new company"
       edit: "Edit this company"
       destroy: "Remove this company"
-      destroy_confirm: "Are you sure you want destroy this company?"
+      destroy_confirm: "Are you sure you want to destroy this company?"
     new:
       title: "Add a new company"
     edit:

--- a/config/locales/layouts.en.yml
+++ b/config/locales/layouts.en.yml
@@ -68,6 +68,7 @@ en:
   yesterday: "Yestersday"
   edit_periods: "Edit periods"
   delete_periods: "Delete periods"
+  warning: Warning
   attributes:
     author: "Edited by"
     created_at: "Created at"

--- a/config/locales/layouts.fr.yml
+++ b/config/locales/layouts.fr.yml
@@ -68,6 +68,7 @@ fr:
   yesterday: "Hier"
   edit_periods: "Editer Périodes"
   delete_periods: "Supprimer Périodes"
+  warning: Avertissement
   attributes:
     author: "Edité par"
     created_at: "Créé le"

--- a/config/locales/lines.en.yml
+++ b/config/locales/lines.en.yml
@@ -8,7 +8,7 @@ en:
       activate: "Activate this line"
       deactivate: "Deactivate this line"
       activate_confirm: "Are you sure you want to activate this line ?"
-      deactivate_confirm: "Are you sure you want tode activate this line ?"
+      deactivate_confirm: "Are you sure you want to deactivate this line ?"
       destroy_confirm: "Are you sure you want to destroy this line ?"
       destroy_selection_confirm: "Are you sure you want to destroy those lines ?"
       import: "Import lines"
@@ -117,7 +117,7 @@ en:
         updated_at: Updated at
         creator_id: "Created by"
         footnotes: "Footnotes"
-        stable_id: External permanent idenifier"
+        stable_id: External permanent identifier
         status: Status
         activated: Activated
         deactivated: Deactivated

--- a/config/locales/networks.en.yml
+++ b/config/locales/networks.en.yml
@@ -5,7 +5,7 @@ en:
       new: "Add a new network"
       edit: "Edit this network"
       destroy: "Remove this network"
-      destroy_confirm: "Are you sure you want destroy this network?"
+      destroy_confirm: "Are you sure you want to destroy this network ?"
     new:
       title: "Add a new network"
     edit:

--- a/config/locales/routing_constraint_zones.en.yml
+++ b/config/locales/routing_constraint_zones.en.yml
@@ -39,6 +39,8 @@ en:
       title: "Update routing constraint zone %{name}"
     show:
       title: "Routing constraint zone %{name}"
+      route_stop_points: Route stop points
+      stop_points: Stop points included in the RCZ
     index:
       title: "Routing constraint zones"
       search_no_results: "No ITL matches your query"

--- a/config/locales/routing_constraint_zones.fr.yml
+++ b/config/locales/routing_constraint_zones.fr.yml
@@ -39,6 +39,8 @@ fr:
       title: "Editer l'ITL : %{name}"
     show:
       title: "Zone de contrainte %{name}"
+      route_stop_points: Arrêts de l'itinéraire
+      stop_points: Arrêts inclus dans l'ITL
     index:
       title: "Interdictions de trafic local"
       search_no_results: "Aucune ITL ne correspond à votre recherche"

--- a/config/locales/stop_areas.en.yml
+++ b/config/locales/stop_areas.en.yml
@@ -28,7 +28,7 @@ en:
       activate: "Activate this stop"
       deactivate: "Deactivate this stop"
       activate_confirm: "Are you sure you want to activate this stop ?"
-      deactivate_confirm: "Are you sure you want tode activate this stop ?"
+      deactivate_confirm: "Are you sure you want to deactivate this stop ?"
       deleted_at: "Activated"
       destroy_confirm: "Are you sure you want destroy this stop and all of his children ?"
       select_parent: "Create or modify the relation child -> parent"

--- a/config/locales/time_tables.en.yml
+++ b/config/locales/time_tables.en.yml
@@ -90,7 +90,7 @@ en:
       to: " to: "
       start_date: "mm/jj/aaaa"
       end_date: "mm/jj/aaaa"
-      title: "timetables"
+      title: "Timetables"
       selection: "Selection"
       selection_all: "All"
       advanced_search: "Advanced Search"


### PR DESCRIPTION
J'ai juste remarqué que quand on switch de locale. Si on utilise un helper dans un decorator l'appli charge toujours l'I18n dans la 1ère locale

```ruby
...Switching from french to english

h.t(key) => toujours en française
t(key) => passe bien en anglais
```

Je ne sais pas à quoi c'est dû mais c'est là d'où viennent la plupart des soucis de traductions que soulève Cyrielle