### PR TITLE
6854 clean up  destroy routes outside referential

### DIFF
--- a/app/models/clean_up.rb
+++ b/app/models/clean_up.rb
@@ -124,6 +124,12 @@ class CleanUp < ApplicationModel
     Chouette::Route.where("id not in (select distinct route_id from journey_patterns)").destroy_all
   end
 
+  def destroy_empty
+    destroy_vehicle_journeys
+    destroy_journey_patterns
+    destroy_routes
+  end
+
   def overlapping_periods
     self.end_date = self.begin_date if self.date_type != 'between'
     Chouette::TimeTablePeriod.where('(period_start, period_end) OVERLAPS (?, ?)', self.begin_date, self.end_date)

--- a/app/models/clean_up.rb
+++ b/app/models/clean_up.rb
@@ -43,7 +43,7 @@ class CleanUp < ApplicationModel
           end
         end
 
-        destroy_vehicle_journeys_outside_referential
+        destroy_routes_outside_referential
         # Disabled for the moment. See #5372
         # destroy_time_tables_outside_referential
 
@@ -98,11 +98,6 @@ class CleanUp < ApplicationModel
     metadatas_period = referential.metadatas_period
     time_tables = Chouette::TimeTable.where('end_date < ? or start_date > ?', metadatas_period.min, metadatas_period.max)
     destroy_time_tables(time_tables)
-  end
-
-  def destroy_vehicle_journeys_outside_referential
-    line_ids = referential.metadatas.pluck(:line_ids).flatten.uniq
-    Chouette::VehicleJourney.joins(:route).where(["routes.line_id not in (?)", line_ids]).destroy_all
   end
 
   def destroy_routes_outside_referential

--- a/app/models/clean_up.rb
+++ b/app/models/clean_up.rb
@@ -49,9 +49,8 @@ class CleanUp < ApplicationModel
         # Disabled for the moment. See #5372
         # destroy_time_tables_outside_referential
 
-        destroy_vehicle_journeys
-        destroy_journey_patterns
-        destroy_routes
+        # Run caller-specified cleanup methods
+        run_methods
       end
     end
   end

--- a/app/models/clean_up.rb
+++ b/app/models/clean_up.rb
@@ -16,6 +16,8 @@ class CleanUp < ApplicationModel
     where(referential_id: referential.id)
   end
 
+  attr_accessor :methods
+
   def end_date_must_be_greater_that_begin_date
     if self.end_date && self.date_type == 'between' && self.begin_date >= self.end_date
       errors.add(:base, I18n.t('activerecord.errors.models.clean_up.invalid_period'))
@@ -52,6 +54,12 @@ class CleanUp < ApplicationModel
         destroy_routes
       end
     end
+  end
+
+  def run_methods
+    return if methods.nil?
+
+    methods.each { |method| send(method) }
   end
 
   def destroy_time_tables_between

--- a/app/models/clean_up.rb
+++ b/app/models/clean_up.rb
@@ -105,6 +105,11 @@ class CleanUp < ApplicationModel
     Chouette::VehicleJourney.joins(:route).where(["routes.line_id not in (?)", line_ids]).destroy_all
   end
 
+  def destroy_routes_outside_referential
+    line_ids = referential.metadatas.pluck(:line_ids).flatten.uniq
+    Chouette::Route.where(['line_id not in (?)', line_ids]).destroy_all
+  end
+
   def destroy_vehicle_journeys
     Chouette::VehicleJourney.where("id not in (select distinct vehicle_journey_id from time_tables_vehicle_journeys)").destroy_all
   end

--- a/spec/models/clean_up_spec.rb
+++ b/spec/models/clean_up_spec.rb
@@ -291,9 +291,9 @@ RSpec.describe CleanUp, :type => :model do
 
       expect(Chouette::Route.exists?(vehicle_journey.route.id)).to be false
       expect(
-        Chouette::JourneyPattern.exists?(vehicle_journey.journey_pattern)
+        Chouette::JourneyPattern.exists?(vehicle_journey.journey_pattern.id)
       ).to be false
-      expect(Chouette::VehicleJourney.exists?(vehicle_journey)).to be false
+      expect(Chouette::VehicleJourney.exists?(vehicle_journey.id)).to be false
     end
   end
 end

--- a/spec/models/clean_up_spec.rb
+++ b/spec/models/clean_up_spec.rb
@@ -296,4 +296,24 @@ RSpec.describe CleanUp, :type => :model do
       expect(Chouette::VehicleJourney.exists?(vehicle_journey.id)).to be false
     end
   end
+
+  describe "#run_methods" do
+    let(:cleaner) { create(:clean_up) }
+
+    it "calls methods in the :methods attribute" do
+      cleaner = create(
+        :clean_up,
+        methods: [:destroy_routes_outside_referential]
+      )
+
+      expect(cleaner).to receive(:destroy_routes_outside_referential)
+      cleaner.run_methods
+    end
+
+    it "doesn't do anything if :methods is nil" do
+      cleaner = create(:clean_up)
+
+      expect { cleaner.run_methods }.not_to raise_error
+    end
+  end
 end

--- a/spec/models/clean_up_spec.rb
+++ b/spec/models/clean_up_spec.rb
@@ -283,5 +283,17 @@ RSpec.describe CleanUp, :type => :model do
         expect(route).not_to be_destroyed
       end
     end
+
+    it "cascades destruction of vehicle journeys and journey patterns" do
+      vehicle_journey = create(:vehicle_journey)
+
+      cleaner.destroy_routes_outside_referential
+
+      expect(Chouette::Route.exists?(vehicle_journey.route.id)).to be false
+      expect(
+        Chouette::JourneyPattern.exists?(vehicle_journey.journey_pattern)
+      ).to be false
+      expect(Chouette::VehicleJourney.exists?(vehicle_journey)).to be false
+    end
   end
 end

--- a/spec/models/clean_up_spec.rb
+++ b/spec/models/clean_up_spec.rb
@@ -297,6 +297,18 @@ RSpec.describe CleanUp, :type => :model do
     end
   end
 
+  describe "#destroy_empty" do
+    it "calls the appropriate destroy methods" do
+      cleaner = create(:clean_up)
+
+      expect(cleaner).to receive(:destroy_vehicle_journeys)
+      expect(cleaner).to receive(:destroy_journey_patterns)
+      expect(cleaner).to receive(:destroy_routes)
+
+      cleaner.destroy_empty
+    end
+  end
+
   describe "#run_methods" do
     let(:cleaner) { create(:clean_up) }
 

--- a/spec/models/clean_up_spec.rb
+++ b/spec/models/clean_up_spec.rb
@@ -264,4 +264,24 @@ RSpec.describe CleanUp, :type => :model do
       }
     end
   end
+
+  describe "#destroy_routes_outside_referential" do
+    let(:line_referential) { create(:line_referential) }
+    let(:line) { create(:line, line_referential: line_referential) }
+    let(:metadata) { create(:referential_metadata, lines: [line]) }
+    let(:referential) { create(:workbench_referential, metadatas: [metadata]) }
+    let(:cleaner) { create(:clean_up, referential: referential) }
+
+    it "destroys routes not in the the referential" do
+      route = create(:route)
+
+      cleaner.destroy_routes_outside_referential
+
+      expect(Chouette::Route.exists?(route.id)).to be false
+
+      line.routes.each do |route|
+        expect(route).not_to be_destroyed
+      end
+    end
+  end
 end


### PR DESCRIPTION
Changes `CleanUp#clean`:

* Instead of destroying vehicle journeys outside the referential, destroy routes outside the referential. This will cascade deletion of vehicle journeys and journey patterns.
* Add a `methods` attribute for configuration which allows optional cleanups to be activated.

Notably, the `#destroy_{vehicle_journeys,journey_patterns,routes}` methods are no longer called by default because they're unnecessary work for referential duplication.

To re-enable them, the cleaner can be called as follows:

	CleanUp.new(methods: [:destroy_empty]).clean