### PR TITLE
7056 Fix JourneyPattern Editor

### DIFF
--- a/app/javascript/journey_patterns/actions/index.js
+++ b/app/javascript/journey_patterns/actions/index.js
@@ -196,7 +196,7 @@ const actions = {
                 let stop_point = val.route_short_description.stop_points[i]
                 stop_point.checked = false
                 val.stop_area_short_descriptions.map((element) => {
-                  if(element.stop_area_short_description.id === stop_point.id){
+                  if(element.stop_area_short_description.position === stop_point.position){
                     stop_point.checked = true
                   }
                 })

--- a/app/views/api/v1/journey_patterns/show.rabl
+++ b/app/views/api/v1/journey_patterns/show.rabl
@@ -23,6 +23,7 @@ node(:vehicle_journey_object_ids) do |journey_pattern|
 end unless root_object.vehicle_journeys.empty?
 
 child :stop_points => :stop_area_short_descriptions do |stop_points|
+  attribute :position
   node do |stop_point|
     cache stop_point.stop_area_id
     partial("api/v1/stop_areas/short_description", :object => stop_point.stop_area)


### PR DESCRIPTION
Fix a bug occuring if a route uses several times the same stops. In the
JourneyPattern Editor, you wouldn't be able to select the stop only once