### PR TITLE
Refs #7386 Fix autocomplete timetable split params

### DIFF
--- a/app/controllers/autocomplete_time_tables_controller.rb
+++ b/app/controllers/autocomplete_time_tables_controller.rb
@@ -27,7 +27,7 @@ class AutocompleteTimeTablesController < ChouetteController
   end
 
   def collection
-    split_params! :comment_or_objectid_cont_any
+    split_params! :unaccented_comment_or_objectid_cont_any
     @time_tables = select_time_tables.search(params[:q]).result.paginate(page: params[:page])
   end
 end

--- a/spec/controllers/autocomplete_time_tables_controller_spec.rb
+++ b/spec/controllers/autocomplete_time_tables_controller_spec.rb
@@ -36,6 +36,14 @@ RSpec.describe AutocompleteTimeTablesController, type: :controller do
         expect(assigns(:time_tables)).to include(blargh)
         expect(assigns(:time_tables)).to_not include(other_time_table)
       end
+
+      it 'should handle whitespaces' do
+        get :index, referential_id: referential.id, q: {unaccented_comment_or_objectid_cont_any: 'écolà militaire'}, format: :json
+        expect(response).to be_success
+        expect(assigns(:time_tables)).to include(time_table)
+        expect(assigns(:time_tables)).to include(blargh)
+        expect(assigns(:time_tables)).to_not include(other_time_table) 
+      end
     end
 
     context "within a route" do
@@ -55,6 +63,14 @@ RSpec.describe AutocompleteTimeTablesController, type: :controller do
           expect(assigns(:time_tables)).to include(blargh)
           expect(assigns(:time_tables)).to_not include(other_time_table)
         end
+
+        it 'should handle whitespaces' do
+          get :index, referential_id: referential.id, q: {unaccented_comment_or_objectid_cont_any: 'écolà militaire'}, format: :json
+          expect(response).to be_success
+          expect(assigns(:time_tables)).to include(time_table)
+          expect(assigns(:time_tables)).to include(blargh)
+          expect(assigns(:time_tables)).to_not include(other_time_table) 
+      end
       end
     end
   end


### PR DESCRIPTION
Juste pour info je crois que l'extension unaccent rajoute des colon ('-') à la place des whitespaces.
Là on a pas de soucies car on split les params à chaque whitespace mais ca peut surement poser soucis à un autre endroit.