### PR TITLE
7535 attempt at solving deadlocks

### DIFF
--- a/app/models/referential.rb
+++ b/app/models/referential.rb
@@ -337,7 +337,9 @@ class Referential < ApplicationModel
   before_save :lock_table, on: [:create, :update]
 
   before_create :create_schema
-  after_commit :clone_schema, if: :created_from
+
+  # Don't use after_commit because of inline_clone (cf created_from)
+  after_create :clone_schema, if: :created_from
   after_create :active!, unless: :created_from
 
   before_destroy :destroy_schema

--- a/app/models/referential.rb
+++ b/app/models/referential.rb
@@ -337,7 +337,7 @@ class Referential < ApplicationModel
   before_save :lock_table, on: [:create, :update]
 
   before_create :create_schema
-  after_create :clone_schema, if: :created_from
+  after_commit :clone_schema, if: :created_from
   after_create :active!, unless: :created_from
 
   before_destroy :destroy_schema
@@ -576,24 +576,24 @@ class Referential < ApplicationModel
   end
 
   def pending!
-    update ready: false, failed_at: nil, archived_at: nil
+    update_columns ready: false, failed_at: nil, archived_at: nil
   end
 
   def failed!
-    update ready: false, failed_at: Time.now, archived_at: nil
+    update_columns ready: false, failed_at: Time.now, archived_at: nil
   end
 
   def active!
-    update ready: true, failed_at: nil, archived_at: nil
+    update_columns ready: true, failed_at: nil, archived_at: nil
   end
 
   def archived!
-    update failed_at: nil, archived_at: Time.now
+    update_columns failed_at: nil, archived_at: Time.now
   end
 
   def merged!
     now = Time.now
-    update failed_at: nil, archived_at: now, merged_at: now
+    update_columns failed_at: nil, archived_at: now, merged_at: now
   end
 
   STATES.each do |s|

--- a/app/models/referential.rb
+++ b/app/models/referential.rb
@@ -577,20 +577,28 @@ class Referential < ApplicationModel
     ready? ? :active : :pending
   end
 
+  def light_update vals
+    if self.persisted?
+      update_columns vals
+    else
+      assign_attributes vals
+    end
+  end
+
   def pending!
-    update_columns ready: false, failed_at: nil, archived_at: nil
+    light_update ready: false, failed_at: nil, archived_at: nil
   end
 
   def failed!
-    update_columns ready: false, failed_at: Time.now, archived_at: nil
+    light_update ready: false, failed_at: Time.now, archived_at: nil
   end
 
   def active!
-    update_columns ready: true, failed_at: nil, archived_at: nil
+    light_update ready: true, failed_at: nil, archived_at: nil
   end
 
   def archived!
-    update_columns failed_at: nil, archived_at: Time.now
+    light_update failed_at: nil, archived_at: Time.now
   end
 
   def merged!

--- a/app/models/referential_cloning.rb
+++ b/app/models/referential_cloning.rb
@@ -91,7 +91,7 @@ class ReferentialCloning < ApplicationModel
     event :failed, after: :update_ended_at do
       transitions :from => :pending, :to => :failed
       after do
-        target_referential.failed!
+        target_referential&.failed!
       end
     end
   end


### PR DESCRIPTION
- run the cloning operation only once the transaction has been comitted 
(thus releasing previously aquired Locks)
- don't lock the DB to set the status of the Referential to `failed`