### PR TITLE
Refs #5986 reenable cache settings middleware

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -100,7 +100,7 @@ Rails.application.configure do
 
   config.middleware.insert_after(ActionDispatch::Static, Rack::LiveReload) if ENV['LIVERELOAD']
   config.middleware.use I18n::JS::Middleware
-  config.middleware.insert_before ActionDispatch::Static, CacheSettings, {
+  config.middleware.insert_after Rack::Sendfile, CacheSettings, {
     /\/assets\/.*/ => {
       cache_control: "max-age=86400, public",
       expires: 86400

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -143,13 +143,12 @@ Rails.application.configure do
 
   config.subscriptions_notifications_recipients = %w{support@enroute.paris chouette-marcom@af83.com}
 
-  # FIXME See #5896
-  # config.middleware.insert_before ActionDispatch::Static, CacheSettings, {
-  #   /\/assets\/.*/ => {
-  #     cache_control: "max-age=#{1.year.to_i}, public",
-  #     expires: 1.year.to_i
-  #   }
-  # }
+  config.middleware.insert_after Rack::Sendfile, CacheSettings, {
+    /\/assets\/.*/ => {
+      cache_control: "max-age=#{1.year.to_i}, public",
+      expires: 1.year.to_i
+    }
+  }
 
   # Set node env for browserify-rails
   # config.browserify_rails.node_env = "production"


### PR DESCRIPTION
```
$ bundle exec rake middleware
use Rack::Sendfile
use CacheSettings
use Rack::Lock
use #<ActiveSupport::Cache::Strategy::LocalCache::Middleware:0x00007f9f17789ea8>
use Rack::Runtime
use Rack::MethodOverride
use ActionDispatch::RequestId
use RequestStore::Middleware
use Rails::Rack::Logger
use ActionDispatch::ShowExceptions
use ActionDispatch::DebugExceptions
use ActionDispatch::RemoteIp
use ActionDispatch::Callbacks
use ActiveRecord::ConnectionAdapters::ConnectionManagement
use ActiveRecord::QueryCache
use ActionDispatch::Cookies
use ActionDispatch::Session::CookieStore
use ActionDispatch::Flash
use ActionDispatch::ParamsParser
use Rack::Head
use Rack::ConditionalGet
use Rack::ETag
use Warden::Manager
use DeviseCasAuthenticatable::SingleSignOut::StoreSessionId
run ChouetteIhm::Application.routes
```