### PR TITLE
7811 Optimize export form

### DIFF
--- a/app/assets/stylesheets/_misc.sass
+++ b/app/assets/stylesheets/_misc.sass
@@ -29,3 +29,8 @@
         white-space: nowrap
         text-overflow: ellipsis
         overflow: hidden
+
+[data-master]
+  display: none
+  & [data-master]
+    display: block

--- a/app/models/referential.rb
+++ b/app/models/referential.rb
@@ -65,6 +65,9 @@ class Referential < ApplicationModel
   scope :archived, -> { where.not(archived_at: nil) }
 
   scope :ready, -> { where(ready: true) }
+  scope :exportable, -> {
+    joins("LEFT JOIN referential_suites ON referentials.referential_suite_id = referential_suites.id").where("ready = ? AND merged_at IS NULL AND (referential_suite_id IS NULL OR referential_suites.current_id = referentials.id)", true)
+  }
   scope :autocomplete, ->(q) {
     if q.present?
       where("name ILIKE '%#{sanitize_sql_like(q)}%'")

--- a/app/views/exports/_form.html.slim
+++ b/app/views/exports/_form.html.slim
@@ -5,12 +5,12 @@
       = form.input :name
     .col-lg-12
       = form.input :type, as: :select, collection: workgroup_exports(workbench.workgroup), label_method: :human_name, input_html: {"data-select2ed" => true}
-      = form.input :referential_id, as: :select, collection: workbench.referentials, label_method: :name, input_html: {"data-select2ed" => true}
+      = form.input :referential_id, as: :select, collection: workbench.referentials.exportable.order("created_at desc"), label_method: :name, input_html: {"data-select2ed" => true}
 
       - workgroup_exports(workbench.workgroup).each do |child|
         .slave data-master="[name='export[type]']" data-value=child.name
           - child.options.each do |attr, option_def|
-            = export_option_input form, export, attr, option_def, child, workbench.referentials
+            = export_option_input form, export, attr, option_def, child, workbench.referentials.exportable
 
   = form.button :submit, t('actions.submit'), class: 'btn btn-default formSubmitr', form: 'wb_export_form'
 


### PR DESCRIPTION
- On ne charge que les référentiels pertinents
- On cache les champs "masqués" en CSS pour ne pas avoir de "flash" quand le JS passe