### PR TITLE
Authorize editing RoutingConstrainZone with minimum 2 StopPoint  #7679 :

### DIFF
--- a/app/models/chouette/route.rb
+++ b/app/models/chouette/route.rb
@@ -93,6 +93,8 @@ module Chouette
           TomTom.enabled?
       }
 
+    scope :with_at_least_three_stop_points, -> { joins(:stop_points).group('routes.id').having("COUNT(stop_points.id) >= 3") }
+
     def clean!
       vehicle_journeys.find_each do |vj|
         vj.vehicle_journey_at_stops.delete_all

--- a/app/models/chouette/routing_constraint_zone.rb
+++ b/app/models/chouette/routing_constraint_zone.rb
@@ -16,7 +16,7 @@ module Chouette
     after_commit :clean_ignored_routing_contraint_zone_ids, on: :destroy
 
     validates_presence_of :name, :stop_points, :route_id
-    validate :stop_points_belong_to_route, :not_all_stop_points_selected, :at_least_one_stop_point_selected
+    validate :stop_points_belong_to_route, :not_all_stop_points_selected, :at_least_two_stop_points_selected
 
     def local_id
       "local-#{self.referential.id}-#{self.route&.line&.get_objectid&.local_id}-#{self.route_id}-#{self.id}"
@@ -57,10 +57,11 @@ module Chouette
       errors.add(:stop_point_ids, I18n.t('activerecord.errors.models.routing_constraint_zone.attributes.stop_points.all_stop_points_selected')) if stop_points.length == route.stop_points.length
     end
 
-    def at_least_one_stop_point_selected
+    def at_least_two_stop_points_selected
       return unless route
+      return unless route.stop_points.length > 2
 
-      errors.add(:stop_point_ids, I18n.t('activerecord.errors.models.routing_constraint_zone.attributes.stop_points.not_enough_stop_points')) if stop_points.empty?
+      errors.add(:stop_point_ids, I18n.t('activerecord.errors.models.routing_constraint_zone.attributes.stop_points.not_enough_stop_points')) if stop_points.length < 2
     end
 
     def stop_points_count

--- a/app/views/routing_constraint_zones/new.html.slim
+++ b/app/views/routing_constraint_zones/new.html.slim
@@ -9,7 +9,7 @@
           .row
             .col-lg-12
               = form.input :name
-              = form.input :route_id, collection: @line.routes, include_blank: false, input_html: { class: 'new_routing_constraint_zone_route', data: {url: new_referential_line_routing_constraint_zone_path(@referential, @line), object: @routing_constraint_zone.to_json }}
+              = form.input :route_id, collection: @line.routes.with_at_least_three_stop_points, include_blank: false, input_html: { class: 'new_routing_constraint_zone_route', data: {url: new_referential_line_routing_constraint_zone_path(@referential, @line), object: @routing_constraint_zone.to_json }}
 
               .separator
 

--- a/config/locales/routing_constraint_zones.en.yml
+++ b/config/locales/routing_constraint_zones.en.yml
@@ -22,7 +22,7 @@ en:
         routing_constraint_zone:
           attributes:
             stop_points:
-              not_enough_stop_points: 'You should specify at least 1 stop point.'
+              not_enough_stop_points: 'You should specify at least 2 stop points.'
               stop_points_not_from_route: 'Stop point does not belong to the Route of this Routing constraint zone.'
               all_stop_points_selected: 'All stop points from route cannot be selected.'
   routing_constraint_zones:

--- a/config/locales/routing_constraint_zones.fr.yml
+++ b/config/locales/routing_constraint_zones.fr.yml
@@ -22,7 +22,7 @@ fr:
         routing_constraint_zone:
           attributes:
             stop_points:
-              not_enough_stop_points: "Une ITL doit contenir au moins un arrêt sur la séquence"
+              not_enough_stop_points: "Une ITL doit contenir au moins deux arrêts sur la séquence"
               stop_points_not_from_route: "Arrêt sur séquence d'arrêts n'appartient pas à la Route de cette Zone de contrainte."
               all_stop_points_selected: "Une ITL ne peut pas couvrir tous les arrêts d'un itinéraire."
   routing_constraint_zones:


### PR DESCRIPTION
 - Change RCZ Validation to force objects to have at least 2 stop points
 - Only list routes with at least three stop points in the new form