### PR TITLE
8205 Add cache to ObjectId formatters

### DIFF
--- a/app/models/chouette/objectid_formatter.rb
+++ b/app/models/chouette/objectid_formatter.rb
@@ -1,0 +1,16 @@
+module Chouette
+  module ObjectidFormatter
+    def self.reset_objectid_providers_cache!
+      @_cache = nil
+    end
+
+    def self.for_objectid_provider(provider_class, provider_scope)
+      @_cache ||= AF83::SmartCache.new
+      cache_key = { provider_class => provider_scope }
+      @_cache.fetch cache_key do
+        provider = provider_class.find_by provider_scope
+        provider.objectid_formatter
+      end
+    end
+  end
+end

--- a/app/models/chouette/trident_active_record.rb
+++ b/app/models/chouette/trident_active_record.rb
@@ -11,6 +11,10 @@ module Chouette
       @referential ||= self.class.current_referential
     end
 
+    def referential_slug
+      Apartment::Tenant.current
+    end
+
     def workgroup
       referential&.workgroup
     end

--- a/app/models/concerns/objectid_formatter_support.rb
+++ b/app/models/concerns/objectid_formatter_support.rb
@@ -3,8 +3,13 @@ module ObjectidFormatterSupport
 
   included do
     extend Enumerize
-    enumerize :objectid_format, in: %w(netex stif_netex stif_reflex stif_codifligne)
+    enumerize :objectid_format,
+              in: %w[netex stif_netex stif_reflex stif_codifligne]
     validates_presence_of :objectid_format
+
+    after_save do
+      Chouette::ObjectidFormatter.reset_objectid_providers_cache!
+    end
 
     def objectid_formatter
       objectid_formatter_class.new

--- a/app/models/concerns/objectid_support.rb
+++ b/app/models/concerns/objectid_support.rb
@@ -60,7 +60,16 @@ module ObjectidSupport
     end
 
     def objectid_formatter
-      self.referential.objectid_formatter
+      Chouette::ObjectidFormatter.for_objectid_provider(*referential_identifier)
+    end
+
+    def referential_identifier
+      %w[line_referential stop_area_referential].each do |name|
+        if (r = self.class.reflections[name])
+          return [r.klass, { id: send(r.foreign_key) }]
+        end
+      end
+      [Referential, { slug: referential_slug }]
     end
 
     def before_validation_objectid

--- a/app/models/import/gtfs.rb
+++ b/app/models/import/gtfs.rb
@@ -241,7 +241,6 @@ class Import::Gtfs < Import::Base
       if route.agency_id.present?
         next unless check_parent_is_valid_or_create_message(Chouette::Company, route.agency_id, resource)
       end
-
       line = line_referential.lines.find_or_initialize_by(registration_number: route.id)
       line.name = route.long_name.presence || route.short_name
       line.number = route.short_name

--- a/lib/af83/smart_cache.rb
+++ b/lib/af83/smart_cache.rb
@@ -1,0 +1,28 @@
+class AF83::SmartCache
+  DEFAULT_MAX_SIZE = 50
+
+  def initialize(opts = {})
+    @max_size = opts[:max_size] || DEFAULT_MAX_SIZE
+    @last_entries = []
+    @_entries = {}
+  end
+
+  def size
+    @_entries.size
+  end
+
+  def fetch(key)
+    val = @_entries[key] ||= begin
+      @last_entries << key
+      yield
+    end
+    clean_entries
+    val
+  end
+
+  protected
+
+  def clean_entries
+    @_entries.delete(@last_entries.shift) while size > @max_size
+  end
+end

--- a/spec/helpers/table_builder_helper_spec.rb
+++ b/spec/helpers/table_builder_helper_spec.rb
@@ -173,8 +173,8 @@ describe TableBuilderHelper, type: :helper do
     end
 
     it "can set a column as non-sortable" do
-      company = build_stubbed(:company)
-      line_referential = build_stubbed(
+      company = create(:company)
+      line_referential = create(
         :line_referential,
         companies: [company]
       )
@@ -288,7 +288,7 @@ describe TableBuilderHelper, type: :helper do
     end
 
     it "can set all columns as non-sortable" do
-      company = build_stubbed(:company)
+      company = create(:company)
       line_referential = build_stubbed(
         :line_referential,
         companies: [company]

--- a/spec/models/chouette/objectid_formatter_spec.rb
+++ b/spec/models/chouette/objectid_formatter_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.describe Chouette::ObjectidFormatter do
+  describe 'objectid_formatter' do
+    let(:referential) { create(:referential, objectid_format: :netex) }
+
+    context "when called from a model" do
+      before(:each) do
+        referential.switch
+        allow_any_instance_of(Chouette::VehicleJourney).to receive(:referential){ referential }
+        @vjs = Array.new(2) { create(:vehicle_journey) }
+        Chouette::ObjectidFormatter.reset_objectid_providers_cache!
+        @initializations_count = 0
+        allow(Referential).to receive(:find_by).and_wrap_original do |m, *args|
+          @initializations_count += 1
+          m.call(*args)
+        end
+        Chouette::ObjectidFormatter.reset_objectid_providers_cache!
+      end
+
+      it 'should be cached' do
+        @vjs.each(&:objectid_formatter)
+        expect(@initializations_count).to eq 1
+      end
+
+      it 'should clear cache' do
+        @vjs.first.objectid_formatter
+        referential.update prefix: :foo
+        @vjs.last.objectid_formatter
+        expect(@initializations_count).to eq 2
+      end
+    end
+
+    it 'should not bloat the memory' do
+      referentials = Array.new(51) { create(:line_referential) }
+      referentials.each do |referential|
+        Chouette::ObjectidFormatter.for_objectid_provider LineReferential, {id: referential.id}
+      end
+      expect(
+        Chouette::ObjectidFormatter.instance_variable_get(:@_cache).size
+      ).to eq 50
+    end
+  end
+end

--- a/spec/models/import/gtfs_spec.rb
+++ b/spec/models/import/gtfs_spec.rb
@@ -4,15 +4,15 @@ RSpec.describe Import::Gtfs do
 
   let(:referential) do
     create :referential do |referential|
-      referential.line_referential.objectid_format = "netex"
-      referential.stop_area_referential.objectid_format = "netex"
+      referential.line_referential.update objectid_format: "netex"
+      referential.stop_area_referential.update objectid_format: "netex"
     end
   end
 
   let(:workbench) do
     create :workbench do |workbench|
-      workbench.line_referential.objectid_format = "netex"
-      workbench.stop_area_referential.objectid_format = "netex"
+      workbench.line_referential.update objectid_format: "netex"
+      workbench.stop_area_referential.update objectid_format: "netex"
     end
   end
 
@@ -499,7 +499,7 @@ RSpec.describe Import::Gtfs do
 
       it 'should create an error message' do
         import.import_calendars
-        
+
         expect do
           import.import_calendar_dates
         end.to(change { Import::Message.count }.by(1))


### PR DESCRIPTION
- Use a reusable SmartCache lib
- We limit the cache size (save some memory for the others)