### PR TITLE
8420 Fix ComplianceCheckSet triggering merge too soon

### DIFF
--- a/app/models/compliance_check_set.rb
+++ b/app/models/compliance_check_set.rb
@@ -22,7 +22,7 @@ class ComplianceCheckSet < ApplicationModel
 
   scope :blocked, -> { where('created_at < ? AND status = ?', 4.hours.ago, 'running') }
 
-  scope :unfinished, -> { where 'status NOT IN (?)', finished_statuses }
+  scope :unfinished, -> { where 'notified_parent_at IS NULL' }
 
   scope :assigned_to_slots, ->(organisation, slots) do
     joins(:compliance_control_set).merge(ComplianceControlSet.assigned_to_slots(organisation, slots))
@@ -69,8 +69,8 @@ class ComplianceCheckSet < ApplicationModel
 
   def do_notify_parent
     if notified_parent_at.nil?
-      parent&.child_change
       update(notified_parent_at: DateTime.now)
+      parent&.child_change
     end
   end
 

--- a/spec/models/merge_spec.rb
+++ b/spec/models/merge_spec.rb
@@ -214,6 +214,7 @@ RSpec.describe Merge do
       it "should reset referential state" do
         merge.merge
         check_set = ComplianceCheckSet.last
+        ComplianceCheckSet.where.not(id: check_set.id).update_all notified_parent_at: Time.now
         expect(check_set.referential).to eq referential
         merge.compliance_check_sets.update_all status:  :successful
         check_set.update status: :failed


### PR DESCRIPTION
Devrait fixer ce scénario: dans le cas d'un merge de 2 JDD, avec un JDC avant merge:
```

| Sidekiq                   | IEV                 |
|                           |                     |
|                           | lancement check #1  |
|                           | fin check #1        |
|                           | Notif fin check #1  |
| lancement check #1        | lancement check #2  |
| fin check #1              | fin check #2        |
| check #1 notif merge      | Notif fin check #2  | => A ce moment, en base, le check 2 est marqué comme "terminé" => on lance le merge :(
| lancement check #2        |                     |
| fin check #2              |                     |
| check #2 notif merge      |                     |


```