### PR TITLE
Refs #8909 add street name to stop areas show view

### DIFF
--- a/app/views/stop_areas/show.html.slim
+++ b/app/views/stop_areas/show.html.slim
@@ -27,13 +27,14 @@
       .col-lg-6.col-md-6.col-sm-12.col-xs-12
         - attributes = {}
         - attributes.merge!("Coordonnées" => geo_data(@stop_area, @stop_area_referential),
+            Chouette::StopArea.tmf('street_name') => @stop_area.street_name,
             Chouette::StopArea.tmf('zip_code') => @stop_area.zip_code,
             Chouette::StopArea.tmf('city_name') => @stop_area.city_name,
             Chouette::StopArea.tmf('country_code') => @stop_area.country_code.presence || '-',
             Chouette::StopArea.tmf('time_zone') => @stop_area.time_zone.presence || '-',
           )
         = definition_list t("stop_areas.form.sections.location"), attributes
-        
+
       .col-lg-6.col-md-6.col-sm-12.col-xs-12
         - attributes = {}
         - attributes.merge!(Chouette::StopArea.tmf('waiting_time') => @stop_area.waiting_time_text) if has_feature?(:stop_area_waiting_time)


### PR DESCRIPTION
# Task

Actuellement dans la show des arrêts, on n'affiche pas l'adresse complète, on a seulement le code postal / ville / pays

-->  le champs "Nom de la rue" doit apparaître