### PR TITLE
Refs #8446 fix referential slug format

### DIFF
--- a/app/models/referential.rb
+++ b/app/models/referential.rb
@@ -497,8 +497,8 @@ class Referential < ApplicationModel
 
   def assign_slug(time_reference = Time)
     self.slug ||= begin
-      prefix = name.parameterize.gsub('-','_').gsub(/[^a-zA-Z_]/,'').gsub(/^_/,'')[0..12]
-      prefix = "referential" if prefix.blank?
+      prefix = name.parameterize.split('-').map { |p| p.gsub(/[^a-z]/, '').presence }
+      prefix = prefix.compact.join('_')[0..12].presence || "referential"
       "#{prefix}_#{time_reference.now.to_i}"
     end if name
   end

--- a/spec/models/referential_spec.rb
+++ b/spec/models/referential_spec.rb
@@ -18,7 +18,8 @@ describe Referential, :type => :model do
         "2018-Hiver-Jezequel-23293MM-Lyon-Nice": "hiver_jezeque_1234567890",
         "-Hiver-Jezequel-MM-Lyon-Nice": "hiver_jezeque_1234567890",
         "Hiver-Jezequel-MM-Lyon-Nice": "hiver_jezeque_1234567890",
-        "20179282": "referential_1234567890"
+        "20179282": "referential_1234567890",
+        "2018 2019 Hiver-Jezequel-MM-Lyon-Nice": "hiver_jezeque_1234567890"
       }
 
       conditions.each do |name, expected_slug|


### PR DESCRIPTION
# Task

On ne peut pas créer un JDD "2018 2019 Qqchose". Le formulaire revient (sans erreur explicite) parce que le slug généré par Chouette n'est pas valide.

Chouette génère un slug "qqchose" qui ne passe pas la validation du format de slug. Il faudrait que Referential#assignslug gère cette situation.