### PR TITLE
9312 - Add rescues to update objects in operations workers

### DIFF
--- a/app/workers/aggregate_worker.rb
+++ b/app/workers/aggregate_worker.rb
@@ -3,6 +3,11 @@ class AggregateWorker
   include Concerns::ImportantWorker
 
   def perform(id)
-    Aggregate.find(id).aggregate!
+    aggregate = Aggregate.find(id)
+    begin
+      aggregate.aggregate!
+    rescue
+      aggregate.failed!
+    end
   end
 end

--- a/app/workers/compliance_check_set_worker.rb
+++ b/app/workers/compliance_check_set_worker.rb
@@ -3,6 +3,11 @@ class ComplianceCheckSetWorker
   include Concerns::LongRunningWorker
 
   def perform(check_set_id, only_internals=false)
-    ComplianceCheckSet.find(check_set_id).perform only_internals
+    check_set = ComplianceCheckSet.find(check_set_id)
+    begin
+      check_set.perform only_internals
+    rescue
+      check_set.failed!
+    end
   end
 end

--- a/app/workers/gtfs_export_worker.rb
+++ b/app/workers/gtfs_export_worker.rb
@@ -20,5 +20,7 @@ class GTFSExportWorker
       gtfs_export.update( status: 'failed' )
     end
     raise
+  rescue
+    @gtfs_export.failed!
   end
 end

--- a/app/workers/gtfs_import_worker.rb
+++ b/app/workers/gtfs_import_worker.rb
@@ -3,6 +3,11 @@ class GtfsImportWorker
   include Concerns::LongRunningWorker
 
   def perform(import_id)
-    Import::Gtfs.find(import_id).import
+    import = Import::Gtfs.find(import_id)
+    begin
+      import.import
+    rescue
+      import.failed!
+    end
   end
 end

--- a/app/workers/merge_worker.rb
+++ b/app/workers/merge_worker.rb
@@ -3,6 +3,11 @@ class MergeWorker
   include Concerns::ImportantWorker
 
   def perform(id)
-    Merge.find(id).merge!
+    merge = Merge.find(id)
+    begin 
+      merge.merge!
+    rescue
+      merge.failed!
+    end
   end
 end

--- a/app/workers/referential_cloning_worker.rb
+++ b/app/workers/referential_cloning_worker.rb
@@ -3,6 +3,11 @@ class ReferentialCloningWorker
   include Concerns::ImportantWorker
 
   def perform(id)
-    ReferentialCloning.find(id).clone_with_status!
+    ref = ReferentialCloning.find(id)
+    begin
+      ref.clone_with_status!
+    rescue
+      ref.failed!
+    end
   end
 end

--- a/app/workers/simple_export_worker.rb
+++ b/app/workers/simple_export_worker.rb
@@ -4,8 +4,12 @@ class SimpleExportWorker
 
   def perform(export_id)
     export = Export::Base.find(export_id)
-    export.update(status: 'running', started_at: Time.now)
-    export.call_exporter
-    export.update(ended_at: Time.now)
+    begin
+      export.update(status: 'running', started_at: Time.now)
+      export.call_exporter
+      export.update(ended_at: Time.now)
+    rescue
+      export.failed!
+    end
   end
 end


### PR DESCRIPTION
Branche version 2 avec le commit du ticket

```
commit 8b8adf84db2169d0e6179590d8d0a3e29f1b8039 (HEAD -> 9312-failed-workers-2, origin/9312-failed-workers-2)
Author: cedricnjanga <ced.njg@gmail.com>
Date:   Wed Nov 28 23:32:39 2018 -0800

    Refs #9312 Add rescues to update objects in operations workers in case sidekiq crash

``` 