### PR TITLE
Refs #7808 Remove user parameter from i18n user key on show page

### DIFF
--- a/config/locales/users.en.yml
+++ b/config/locales/users.en.yml
@@ -23,7 +23,7 @@ en:
     edit:
       title: "Update user %{name}"
     show:
-      title: "User %{name}"
+      title: "Users"
     index:
       title: "Users"
       name_or_email_cont: "Name or email"

--- a/config/locales/users.fr.yml
+++ b/config/locales/users.fr.yml
@@ -23,7 +23,7 @@ fr:
     edit:
       title: "Editer l'utilisateur %{name}"
     show:
-      title: "Utilisateur %{name}"
+      title: "Utilisateurs"
     index:
       title: "Utilisateurs"
       name_or_email_cont: "Nom ou email"


### PR DESCRIPTION
J'ai enlevé le paramètre user car on a pas (je crois de vraie page show pour un user).

En fait lors de la confirmation voici les params envoyés par le devise controller : 

```
{"confirmation_token"=>"_Vn7Cz-dAC1JCYMPmKmg",
 "controller"=>"devise/confirmations",
 "action"=>"show"}
```

Donc vu que l'action est show, par défaut on veut le param :user. 
Forcément enlever la clé c'est le plus simple.
Sinon à part ca voudrait dire renommer la route pour avoir une action custom de la part du devise controller ?