### PR TITLE
Refs #9504 Fix operation notification

### DIFF
--- a/app/models/concerns/notifiable_support.rb
+++ b/app/models/concerns/notifiable_support.rb
@@ -3,7 +3,7 @@ module NotifiableSupport
 
   included do
     extend Enumerize
-    enumerize :notification_target, in: %w[user workbench], default: :user
+    enumerize :notification_target, in: %w[none user workbench], default: :none
     belongs_to :user
   end
 
@@ -26,14 +26,14 @@ module NotifiableSupport
       Rails.logger.error "Can't notify users: #{e.message} #{e.backtrace.join("\n")}"
     end
 
-    notified_recipients!
+    notify_recipients!
   end
 
   def notified_recipients?
     notified_recipients_at.present?
   end
 
-  def notified_recipients!
+  def notify_recipients!
     update_column :notified_recipients_at, Time.now
   end
 
@@ -42,7 +42,7 @@ module NotifiableSupport
   end
 
   def notification_recipients
-    return [] unless notification_target.present?
+    return [] unless has_notification_recipients?
 
     users = if notification_target.to_s == 'user'
       [user]
@@ -51,5 +51,9 @@ module NotifiableSupport
     end
 
     users.compact.map(&:email_recipient)
+  end
+
+  def has_notification_recipients?
+    notification_target.present? && notification_target.to_s != 'none'
   end
 end

--- a/app/observers/notifiable_operation_observer.rb
+++ b/app/observers/notifiable_operation_observer.rb
@@ -14,6 +14,6 @@ class NotifiableOperationObserver < ActiveRecord::Observer
   private
 
   def email_sendable_for?(model)
-    model.class.finished_statuses.include?(model.status) && model.notified_recipients_at.blank?
+    model.class.finished_statuses.include?(model.status) && model.notified_recipients_at.blank? && model.has_notification_recipients?
   end
 end

--- a/app/views/aggregates/_form.html.slim
+++ b/app/views/aggregates/_form.html.slim
@@ -13,7 +13,7 @@
 
   .row
     .col-lg-12
-      = form.input :notification_target, collection: Aggregate.notification_target_options, include_blank: :translate
+      = form.input :notification_target, collection: Aggregate.notification_target_options, selected: :user
 
   .row
     .col-lg-12

--- a/app/views/exports/_form.html.slim
+++ b/app/views/exports/_form.html.slim
@@ -5,7 +5,7 @@
       = form.input :name
 
     .col-lg-12
-      = form.input :notification_target, collection: Export::Base.notification_target_options, include_blank: :translate
+      = form.input :notification_target, collection: Export::Base.notification_target_options, selected: :user
 
     .col-lg-12
       = form.input :type, as: :select, collection: workgroup_exports(workbench.workgroup), label_method: :human_name, input_html: {"data-select2ed" => true}

--- a/app/views/imports/_form.html.slim
+++ b/app/views/imports/_form.html.slim
@@ -6,7 +6,7 @@
 
   .row
     .col-lg-12
-      = form.input :notification_target, collection: Import::Base.notification_target_options, include_blank: :translate
+      = form.input :notification_target, collection: Import::Base.notification_target_options, selected: :user
 
   .row
     .col-lg-12

--- a/app/views/merges/_form.html.slim
+++ b/app/views/merges/_form.html.slim
@@ -13,7 +13,7 @@
 
   .row
     .col-lg-12
-      = form.input :notification_target, collection: Merge.notification_target_options, include_blank: :translate
+      = form.input :notification_target, collection: Merge.notification_target_options, selected: :user
 
   .row.merge-referentials-selector
     .col

--- a/config/locales/operation_support.en.yml
+++ b/config/locales/operation_support.en.yml
@@ -14,3 +14,4 @@ en:
     notification_targets:
       user:       User
       workbench:  Workbench
+      none:       None

--- a/config/locales/operation_support.fr.yml
+++ b/config/locales/operation_support.fr.yml
@@ -14,3 +14,4 @@ fr:
     notification_targets:
       user:       Utilisateur
       workbench:  Espace de travail
+      none:       Aucune notification


### PR DESCRIPTION
Je ne sais pas pourquoi même si `NotifiableSupport#notification_recipients`renvoit bien `[]`, un mail est quand même envoyé à la fin de l'opération.