### PR TITLE
10550 Fix bug in Copy/Paste

### DIFF
--- a/app/javascript/vehicle_journeys/components/CopyModal.js
+++ b/app/javascript/vehicle_journeys/components/CopyModal.js
@@ -40,7 +40,7 @@ export default class CopyModal extends Component {
   }
 
   pasteFromClipboardAvailable() {
-    return !! navigator.clipboard.readText
+    return !! (navigator.clipboard && navigator.clipboard.readText)
   }
 
   pasteFromClipboard() {


### PR DESCRIPTION
When `navigator.clipboard` is not defined