### PR TITLE
10866 Add a method to easily profile imports

### DIFF
--- a/app/models/application_model.rb
+++ b/app/models/application_model.rb
@@ -4,6 +4,16 @@ class ApplicationModel < ::ActiveRecord::Base
   self.abstract_class = true
 
   class << self
+    def skip_objectid_uniqueness?
+      @skip_objectid_uniqueness
+    end
+
+    def skipping_objectid_uniqueness
+      @skip_objectid_uniqueness = true
+      yield
+      @skip_objectid_uniqueness = false
+    end
+    
     def add_light_belongs_to(rel_name)
       rel = reflections[rel_name.to_s]
       raise "missing relation #{rel_name} on #{self.name}" unless rel

--- a/app/models/chouette/company.rb
+++ b/app/models/chouette/company.rb
@@ -23,6 +23,5 @@ module Chouette
       self.class.current_workgroup || workgroup_without_cache
     end
     alias_method_chain :workgroup, :cache
-    
   end
 end

--- a/app/models/chouette/journey_pattern.rb
+++ b/app/models/chouette/journey_pattern.rb
@@ -14,6 +14,8 @@ module Chouette
     has_many :stop_areas, through: :stop_points
     has_many :courses_stats, class_name: "Stat::JourneyPatternCoursesByDate"
 
+    scope :light, ->{ select(:id, :name, :route_id, :objectid) }
+
     validates_presence_of :route
     validates_presence_of :name
 

--- a/app/models/chouette/objectid_formatter/base.rb
+++ b/app/models/chouette/objectid_formatter/base.rb
@@ -10,6 +10,9 @@ module Chouette
       def table_name(model_class)
         model_class.table_name.split(".").last
       end
+
+      def objectid(model)
+      end
     end
   end
 end

--- a/app/models/chouette/objectid_formatter/netex.rb
+++ b/app/models/chouette/objectid_formatter/netex.rb
@@ -7,12 +7,16 @@ module Chouette
       end
 
       def before_validation(model)
-        oid = Chouette::Objectid::Netex.new(local_id: SecureRandom.uuid, object_type: model.class.name.gsub('Chouette::',''))
+        oid = objectid(model)
         model.update(objectid: oid.to_s) if oid.valid?
       end
 
       def after_commit(model)
         # unused method in this context
+      end
+
+      def objectid(model)
+        Chouette::Objectid::Netex.new(local_id: SecureRandom.uuid, object_type: model.class.name.gsub('Chouette::',''))
       end
 
       def get_objectid(definition)

--- a/app/models/chouette/time_table.rb
+++ b/app/models/chouette/time_table.rb
@@ -9,7 +9,7 @@ module Chouette
 
     acts_as_taggable
 
-    attr_accessor :tag_search
+    attr_accessor :tag_search, :skip_save_shortcuts
 
     def self.ransackable_attributes auth_object = nil
       (column_names + ['tag_search']) + _ransackers.keys
@@ -204,6 +204,7 @@ module Chouette
     end
 
     def save_shortcuts
+      return if skip_save_shortcuts
       shortcuts_update
       return unless changes.key?(:start_date) || changes.key?(:end_date)
 
@@ -212,21 +213,14 @@ module Chouette
 
     def shortcuts_update(date=nil)
       dates_array = bounding_dates
-      #if new_record?
-        if dates_array.empty?
-          self.start_date=nil
-          self.end_date=nil
-        else
-          self.start_date=dates_array.min
-          self.end_date=dates_array.max
-        end
-      #else
-      # if dates_array.empty?
-      #   update_attributes :start_date => nil, :end_date => nil
-      # else
-      #   update_attributes :start_date => dates_array.min, :end_date => dates_array.max
-      # end
-      #end
+
+      if dates_array.empty?
+        self.start_date=nil
+        self.end_date=nil
+      else
+        self.start_date=dates_array.min
+        self.end_date=dates_array.max
+      end
     end
 
     def validity_out_from_on?(expected_date)

--- a/app/models/concerns/checksum_support.rb
+++ b/app/models/concerns/checksum_support.rb
@@ -85,8 +85,8 @@ module ChecksumSupport
     Chouette::ChecksumManager.current.log("Updated #{self.class.name}:#{id} checksum: #{self.checksum}")
   end
 
-  def update_checksum_without_callbacks!
-    set_current_checksum_source
+  def update_checksum_without_callbacks!(db_lookup: true)
+    set_current_checksum_source(db_lookup: db_lookup)
     _checksum = Digest::SHA256.new.hexdigest(checksum_source)
     Chouette::ChecksumManager.current.log("Compute checksum for #{self.class.name}:#{id} checksum_source:'#{checksum_source}' checksum: #{_checksum}")
     if _checksum != self.checksum

--- a/app/models/concerns/checksum_support.rb
+++ b/app/models/concerns/checksum_support.rb
@@ -72,10 +72,12 @@ module ChecksumSupport
     self.checksum_source = self.current_checksum_source(db_lookup: db_lookup)
   end
 
-  def update_checksum
-    if self.checksum_source_changed?
+  def update_checksum(force: false, silent: false)
+    if self.checksum_source_changed? || force
       self.checksum = Digest::SHA256.new.hexdigest(self.checksum_source)
-      Chouette::ChecksumManager.current.log("Changed #{self.class.name}:#{id} checksum: #{self.checksum}, checksum_source: #{self.checksum_source}")
+    end
+    if (self.checksum_source_changed? || self.checksum_changed?) && !silent
+      Chouette::ChecksumManager.current.log("Changed #{self.class.name}:#{id} checksum: #{self.checksum}, checksum_source: #{self.checksum_source}") 
     end
   end
 

--- a/app/models/concerns/custom_fields_support.rb
+++ b/app/models/concerns/custom_fields_support.rb
@@ -4,6 +4,7 @@ module CustomFieldsSupport
   included do
     validate :custom_fields_values_are_valid
     after_initialize :initialize_custom_fields
+    attr_accessor :skip_custom_fields_initialization
 
     def self.reset_custom_fields
       @_custom_fields = nil
@@ -84,6 +85,7 @@ module CustomFieldsSupport
     end
 
     def initialize_custom_fields
+      return if skip_custom_fields_initialization
       return if custom_fields_initialized?
       return unless self.attributes.has_key?("custom_field_values")
       return unless self.workgroup.present?
@@ -102,6 +104,7 @@ module CustomFieldsSupport
 
     private
     def custom_fields_values_are_valid
+      return unless self[:custom_fields_values].present?
       custom_fields.values.all?{|cf| cf.valid?}
     end
   end

--- a/app/models/concerns/custom_fields_support.rb
+++ b/app/models/concerns/custom_fields_support.rb
@@ -89,6 +89,7 @@ module CustomFieldsSupport
       return if custom_fields_initialized?
       return unless self.attributes.has_key?("custom_field_values")
       return unless self.workgroup.present?
+      
       self.custom_field_values ||= {}
       custom_fields.values.each &:initialize_custom_field
       custom_fields.each do |k, v|
@@ -104,7 +105,8 @@ module CustomFieldsSupport
 
     private
     def custom_fields_values_are_valid
-      return unless self[:custom_fields_values].present?
+      return if skip_custom_fields_initialization
+
       custom_fields.values.all?{|cf| cf.valid?}
     end
   end

--- a/app/models/concerns/iev_interfaces/resource.rb
+++ b/app/models/concerns/iev_interfaces/resource.rb
@@ -14,6 +14,8 @@ module IevInterfaces::Resource
   end
 
   def each(collection, opts = {})
+    checksum_manager_method = opts[:skip_checksums] ? :no_updates : :transaction
+
     inner_block = proc do |items|
       items.each do |item|
         inc_rows_count
@@ -24,7 +26,7 @@ module IevInterfaces::Resource
     transaction_block = proc do |items|
       if opts[:transaction]
         ActiveRecord::Base.transaction do
-          Chouette::ChecksumManager.transaction do
+          Chouette::ChecksumManager.send(checksum_manager_method) do
             inner_block.call items
           end
         end

--- a/app/models/concerns/iev_interfaces/task.rb
+++ b/app/models/concerns/iev_interfaces/task.rb
@@ -7,6 +7,8 @@ module IevInterfaces::Task
     has_one :organisation, through: :workbench
     belongs_to :referential
 
+    delegate :workgroup, to: :workbench
+
     mount_uploader :file, ImportUploader
     validates_integrity_of :file
 

--- a/app/models/concerns/local_import_support.rb
+++ b/app/models/concerns/local_import_support.rb
@@ -18,16 +18,18 @@ module LocalImportSupport
       import.profile_options = profile_options
       import.name = "Profile #{File.basename(filepath)}"
       import.save!
-      if profile_options[:reuse_referential]
-        r = if profile_options[:reuse_referential].is_a?(Referential)
-          profile_options[:reuse_referential]
+      if profile_options[:operations]
+        if profile_options[:reuse_referential]
+          r = if profile_options[:reuse_referential].is_a?(Referential)
+            profile_options[:reuse_referential]
+          else
+            Referential.where(name: import.referential_name).last
+          end
+          import.referential = r
+          r.switch
         else
-          Referential.where(name: import.referential_name).last
+          import.create_referential
         end
-        import.referential = r
-        r.switch
-      else
-        import.create_referential
       end
       import.save!
       if profile_options[:operations]

--- a/app/models/concerns/local_import_support.rb
+++ b/app/models/concerns/local_import_support.rb
@@ -118,16 +118,18 @@ module LocalImportSupport
   def profile_tag(tag)
     @current_profile_scope ||= []
     @current_profile_scope << tag
+    out = time = nil
     begin
       time = ::Benchmark.realtime do
         puts "START PROFILING #{@current_profile_scope.join('.')}"  if profile?
-        yield
+        out = yield
       end
       add_profile_time @current_profile_scope.join('.'), time if profile?
     ensure
-      puts "END PROFILING #{@current_profile_scope.join('.')}" if profile?
+      puts "END PROFILING #{@current_profile_scope.join('.')} in #{time}s" if profile?
       @current_profile_scope.pop
     end
+    out
   end
 
   def profile_operation(operation, &block)

--- a/app/models/concerns/local_import_support.rb
+++ b/app/models/concerns/local_import_support.rb
@@ -238,6 +238,7 @@ module LocalImportSupport
 
   def save_model(model, filename: nil, line_number:  nil, column_number: nil, resource: nil)
     profile_tag "save_model.#{model.class.name}" do
+      return unless model.changed?
 
       if resource
         filename ||= "#{resource.name}.txt"

--- a/app/models/concerns/objectid_support.rb
+++ b/app/models/concerns/objectid_support.rb
@@ -28,9 +28,12 @@ module ObjectidSupport
       end
 
       def skipping_objectid_uniqueness
-        @skip_objectid_uniqueness = true
-        yield
-        @skip_objectid_uniqueness = false
+        begin
+          @skip_objectid_uniqueness = true
+          yield
+        ensure
+          @skip_objectid_uniqueness = false
+        end
       end
 
       def search_with_objectid args={}

--- a/app/models/concerns/objectid_support.rb
+++ b/app/models/concerns/objectid_support.rb
@@ -24,7 +24,7 @@ module ObjectidSupport
     class << self
 
       def skip_objectid_uniqueness?
-        @skip_objectid_uniqueness
+        ApplicationModel.skip_objectid_uniqueness? || @skip_objectid_uniqueness
       end
 
       def skipping_objectid_uniqueness

--- a/app/models/import/gtfs.rb
+++ b/app/models/import/gtfs.rb
@@ -118,7 +118,7 @@ class Import::Gtfs < Import::Base
         line.name = route.long_name.presence || route.short_name
         line.number = route.short_name
         line.published_name = route.long_name
-        unless route.agency_id == line.company.registration_number
+        unless route.agency_id == line.company&.registration_number
           line.company = line_referential.companies.find_by(registration_number: route.agency_id) if route.agency_id.present?
         end
         line.comment = route.desc

--- a/app/models/import/gtfs.rb
+++ b/app/models/import/gtfs.rb
@@ -80,8 +80,8 @@ class Import::Gtfs < Import::Base
 
         stop_area.name = stop.name
         stop_area.area_type = stop.location_type == '1' ? :zdlp : :zdep
-        stop_area.latitude = stop.lat && BigDecimal.new(stop.lat)
-        stop_area.longitude = stop.lon && BigDecimal.new(stop.lon)
+        stop_area.latitude = stop.lat && BigDecimal(stop.lat)
+        stop_area.longitude = stop.lon && BigDecimal(stop.lon)
         stop_area.kind = :commercial
         stop_area.deleted_at = nil
         stop_area.confirmed_at ||= Time.now

--- a/app/models/import/gtfs.rb
+++ b/app/models/import/gtfs.rb
@@ -1,3 +1,6 @@
+class JourneyPatternsStopPoint < ActiveRecord::Base
+end
+
 class Import::Gtfs < Import::Base
   include LocalImportSupport
 
@@ -53,7 +56,7 @@ class Import::Gtfs < Import::Base
     referential.pending!
 
     import_resources :calendars, :calendar_dates, :calendar_checksums unless check_calendar_files_missing_and_create_message
-    import_resources :trips, :stop_times
+    import_resources :trips, :stop_times, :missing_checksums
   end
 
   def import_agencies
@@ -162,6 +165,7 @@ class Import::Gtfs < Import::Base
         create_resource(:stop_times).each(
           source.stop_times.group_by(&:trip_id),
           transaction: true,
+          skip_checksums: true,
           memory_profile: -> { "Import stop times from #{rows_count}" }
         ) do |row, resource|
             begin
@@ -170,59 +174,69 @@ class Import::Gtfs < Import::Base
                 to_be_saved = []
                 prev_trip_id = trip_id
 
-                trip = @trips[trip_id]
-                line = line_referential.lines.find_by registration_number: trip.route_id
-                route = referential.routes.build line: line
-                route.wayback = (trip.direction_id == '0' ? :outbound : :inbound)
-                name = route.published_name = trip.headsign.presence || trip.short_name.presence || route.wayback.to_s.capitalize
-                route.name = name
-                to_be_saved << route
+                stop_points_with_times = stop_points = vehicle_journey = journey_pattern = route = nil
+                profile_tag 'preparation' do
+                  trip = @trips[trip_id]
+                  line = line_referential.lines.find_by registration_number: trip.route_id
+                  route = referential.routes.build line: line
+                  route.wayback = (trip.direction_id == '0' ? :outbound : :inbound)
+                  name = route.published_name = trip.headsign.presence || trip.short_name.presence || route.wayback.to_s.capitalize
+                  route.name = name
+                  to_be_saved << route
 
-                journey_pattern = route.journey_patterns.build name: name
-                # to_be_saved << journey_pattern
+                  journey_pattern = route.journey_patterns.build name: name, skip_custom_fields_initialization: true
+                  # to_be_saved << journey_pattern
 
-                vehicle_journey = journey_pattern.vehicle_journeys.build route: route
-                vehicle_journey.published_journey_name = trip.short_name.presence || trip.id
+                  vehicle_journey = journey_pattern.vehicle_journeys.build route: route, skip_custom_fields_initialization: true
+                  vehicle_journey.published_journey_name = trip.short_name.presence || trip.id
 
-                to_be_saved << vehicle_journey
+                  to_be_saved << vehicle_journey
 
-                time_table = referential.time_tables.find_by(id: time_tables_by_service_id[trip.service_id]) if time_tables_by_service_id[trip.service_id]
-                if time_table
-                  vehicle_journey.time_tables << time_table
-                else
-                  create_message(
-                    {
-                      criticity: :warning,
-                      message_key: 'gtfs.trips.unknown_service_id',
-                      message_attributes: { service_id: trip.service_id },
-                      resource_attributes: {
-                        filename: "#{resource.name}.txt",
-                        line_number: resource.rows_count,
-                        column_number: 0
-                      }
-                    },
-                    resource: resource,
-                    commit: true
-                  )
-                end
+                  time_table = referential.time_tables.find_by(id: time_tables_by_service_id[trip.service_id]) if time_tables_by_service_id[trip.service_id]
+                  if time_table
+                    vehicle_journey.time_tables << time_table
+                  else
+                    create_message(
+                      {
+                        criticity: :warning,
+                        message_key: 'gtfs.trips.unknown_service_id',
+                        message_attributes: { service_id: trip.service_id },
+                        resource_attributes: {
+                          filename: "#{resource.name}.txt",
+                          line_number: resource.rows_count,
+                          column_number: 0
+                        }
+                      },
+                      resource: resource,
+                      commit: true
+                    )
+                  end
 
-                stop_times.sort_by! { |s| s.stop_sequence.to_i }
+                  stop_times.sort_by! { |s| s.stop_sequence.to_i }
 
-                raise InvalidTripTimesError unless consistent_stop_times(stop_times)
+                  raise InvalidTripTimesError unless consistent_stop_times(stop_times)
 
-                stop_points_with_times = stop_times.each_with_index.map do |stop_time, i|
-                  [stop_time, import_stop_time(stop_time, route, resource, i)]
-                end
-                to_be_saved.each do |model|
-                  save_model model, resource: resource
-                end
+                  stop_points_with_times = stop_times.each_with_index.map do |stop_time, i|
+                    [stop_time, import_stop_time(stop_time, route, resource, i)]
+                  end
 
-                stop_points = stop_points_with_times.map do |s|
-                  stop_point = s.last
-                  @objectid_formatter ||= Chouette::ObjectidFormatter.for_objectid_provider(StopAreaReferential, id: referential.stop_area_referential_id)
-                  stop_point[:route_id] = route.id
-                  stop_point[:objectid] = @objectid_formatter.objectid(stop_point)
-                  stop_point
+                  profile_tag 'save_models' do
+                    ApplicationModel.skipping_objectid_uniqueness do
+                      to_be_saved.each do |model|
+                        save_model model, resource: resource
+                      end
+                    end
+                  end
+
+                  stop_points = profile_tag 'stop_points_mapping' do
+                    stop_points_with_times.map do |s|
+                      stop_point = s.last
+                      @objectid_formatter ||= Chouette::ObjectidFormatter.for_objectid_provider(StopAreaReferential, id: referential.stop_area_referential_id)
+                      stop_point[:route_id] = route.id
+                      stop_point[:objectid] = @objectid_formatter.objectid(stop_point)
+                      stop_point
+                    end
+                  end
                 end
 
                 profile_tag 'stop_points_bulk_insert' do
@@ -235,11 +249,28 @@ class Import::Gtfs < Import::Base
                   stop_points = Chouette::StopPoint.find worker.result_sets.last.rows
                 end
                 profile_tag 'add_stop_points_to_jp' do
-                  journey_pattern.stop_points = stop_points
+                  JourneyPatternsStopPoint.bulk_insert do |worker|
+                    stop_points.each do |stop_point|
+                      worker.add journey_pattern_id: journey_pattern.id, stop_point_id: stop_point.id
+                    end
+                  end
+
+                  journey_pattern.stop_points.reload
+
+
+                  journey_pattern.shortcuts_update_for_add(stop_points.last)
+                  # skip skipping_objectid_uniqueness
                 end
 
-                stop_points.each_with_index do |stop_point, i|
-                  add_stop_point stop_points_with_times[i].first, stop_point, journey_pattern, resource
+                profile_tag 'vjas_bulk_insert' do
+                  Chouette::VehicleJourneyAtStop.bulk_insert do |worker|
+                    # stop_points.each do |stop_point|
+                    #   worker.add vehicle_journey_id: vehicle_journey.id, stop_point_id: stop_point.id, for_boarding: :normal, for_alighting: :normal
+                    # end
+                    stop_points.each_with_index do |stop_point, i|
+                      add_stop_point stop_points_with_times[i].first, stop_point, journey_pattern, vehicle_journey, resource, worker
+                    end
+                  end
                 end
                 save_model journey_pattern, resource: resource
               end
@@ -302,36 +333,43 @@ class Import::Gtfs < Import::Base
   end
 
   def import_stop_time(stop_time, route, resource, position)
-    unless_parent_model_in_error(Chouette::StopArea, stop_time.stop_id, resource) do
+    profile_tag 'import_stop_time' do
+      unless_parent_model_in_error(Chouette::StopArea, stop_time.stop_id, resource) do
 
-      if position == 0
-        departure_time = GTFS::Time.parse(stop_time.departure_time)
-        raise InvalidTimeError.new(stop_time.departure_time) unless departure_time.present?
-        arrival_time = GTFS::Time.parse(stop_time.arrival_time)
-        raise InvalidTimeError.new(stop_time.arrival_time) unless arrival_time.present?
-        raise InvalidTripNonZeroFirstOffsetError unless departure_time.day_offset.zero? && arrival_time.day_offset.zero?
+        if position == 0
+          departure_time = GTFS::Time.parse(stop_time.departure_time)
+          raise InvalidTimeError.new(stop_time.departure_time) unless departure_time.present?
+          arrival_time = GTFS::Time.parse(stop_time.arrival_time)
+          raise InvalidTimeError.new(stop_time.arrival_time) unless arrival_time.present?
+          raise InvalidTripNonZeroFirstOffsetError unless departure_time.day_offset.zero? && arrival_time.day_offset.zero?
+        end
+
+        stop_area_id = @stop_areas_id_by_registration_number[stop_time.stop_id]
+        Chouette::StopPoint.new(stop_area_id: stop_area_id, position: position )
       end
-
-      stop_area_id = @stop_areas_id_by_registration_number[stop_time.stop_id]
-      Chouette::StopPoint.new(stop_area_id: stop_area_id, position: position )
     end
   end
 
-  def add_stop_point(stop_time, stop_point, journey_pattern, resource)
+  def add_stop_point(stop_time, stop_point, journey_pattern, vehicle_journey, resource, worker)
     profile_tag 'add_stop_point' do
       # JourneyPattern#vjas_add creates automaticaly VehicleJourneyAtStop
 
-      vehicle_journey_at_stop = journey_pattern.vehicle_journey_at_stops.where(stop_point_id: stop_point.id).last
-      departure_time = GTFS::Time.parse(stop_time.departure_time)
-      raise InvalidTimeError.new(stop_time.departure_time) unless departure_time.present?
+      vehicle_journey_at_stop = journey_pattern.vehicle_journey_at_stops.build(stop_point_id: stop_point.id)
+      departure_time = nil
+      arrival_time = nil
 
-      arrival_time = GTFS::Time.parse(stop_time.arrival_time)
-      raise InvalidTimeError.new(stop_time.arrival_time) unless arrival_time.present?
+      profile_tag 'parse_times' do
+        departure_time = GTFS::Time.parse(stop_time.departure_time)
+        raise InvalidTimeError.new(stop_time.departure_time) unless departure_time.present?
 
+        arrival_time = GTFS::Time.parse(stop_time.arrival_time)
+        raise InvalidTimeError.new(stop_time.arrival_time) unless arrival_time.present?
+      end
       if @previous_stop_sequence.nil? || stop_time.stop_sequence.to_i <= @previous_stop_sequence
         @vehicle_journey_at_stop_first_offset = departure_time.day_offset
       end
 
+      vehicle_journey_at_stop.vehicle_journey = vehicle_journey
       vehicle_journey_at_stop.departure_time = departure_time.time(@default_time_zone)
       vehicle_journey_at_stop.arrival_time = arrival_time.time(@default_time_zone)
       vehicle_journey_at_stop.departure_day_offset = departure_time.day_offset - @vehicle_journey_at_stop_first_offset
@@ -341,7 +379,8 @@ class Import::Gtfs < Import::Base
 
       @previous_stop_sequence = stop_time.stop_sequence.to_i
 
-      save_model vehicle_journey_at_stop, resource: resource
+      worker.add vehicle_journey_at_stop.attributes
+      # save_model vehicle_journey_at_stop, resource: resource
     end
   end
 
@@ -398,6 +437,39 @@ class Import::Gtfs < Import::Base
 
   def import_calendar_checksums
     referential.time_tables.includes(:dates, :periods).find_each{ |tt| tt.update_checksum_without_callbacks!(db_lookup: false) }
+  end
+
+  def update_checkum_in_batches(collection)
+    collection.find_in_batches do |group|
+      ids = []
+      checksums = []
+      checksum_sources = []
+      group.each do |r|
+        ids << r.id
+        checksum_sources << self.class.sanitize(r.current_checksum_source(db_lookup: false))
+        checksums << Digest::SHA256.new.hexdigest(checksum_sources.last)
+      end
+      sql = <<SQL
+        UPDATE #{referential.slug}.#{collection.klass.table_name} tmp SET checksum_source = data_table.checksum_source, checksum = data_table.checksum
+        FROM
+        (select unnest(array[#{ids.join(",")}]) as id,
+        unnest(array['#{checksums.join("','")}']) as checksum,
+        unnest(array[#{checksum_sources.join(",")}]) as checksum_source) as data_table
+        where tmp.id = data_table.id;
+SQL
+      ActiveRecord::Base.connection.execute sql
+    end
+  end
+
+  def import_missing_checksums
+    Chouette::JourneyPattern.within_workgroup(workgroup) do
+      Chouette::VehicleJourney.within_workgroup(workgroup) do
+        update_checkum_in_batches referential.vehicle_journey_at_stops.select(:id, :checksum_source, :departure_time, :arrival_time, :departure_day_offset, :arrival_day_offset, :checksum, :checksum_source)
+        update_checkum_in_batches referential.routes.select(:id, :checksum_source, :name, :published_name, :wayback).includes(:stop_points, :routing_constraint_zones)
+        update_checkum_in_batches referential.journey_patterns.select(:id, :checksum_source, :custom_field_values, :name, :published_name, :registration_number, :costs).includes(:stop_points)
+        update_checkum_in_batches referential.vehicle_journeys.select(:id, :checksum_source, :custom_field_values, :published_journey_name, :published_journey_identifier, :ignored_routing_contraint_zone_ids, :ignored_stop_area_routing_constraint_ids, :company_id).includes(:company_light, :footnotes, :vehicle_journey_at_stops, :purchase_windows)
+      end
+    end
   end
 
   def find_stop_parent_or_create_message(stop_area_name, parent_station, resource)

--- a/app/services/referential_audit/checksums.rb
+++ b/app/services/referential_audit/checksums.rb
@@ -8,20 +8,22 @@ class ReferentialAudit
     def find_faulty
       faulty = []
       models = [
-        Chouette::Footnote.select(:id, :checksum_source, :code, :label),
-        Chouette::JourneyPattern.select(:id, :checksum_source, :custom_field_values, :name, :published_name, :registration_number, :costs).includes(:stop_points),
-        Chouette::PurchaseWindow.select(:id, :checksum_source, :name, :color, :date_ranges),
-        Chouette::Route.select(:id, :checksum_source, :name, :published_name, :wayback).includes(:stop_points, :routing_constraint_zones),
-        Chouette::RoutingConstraintZone.select(:id, :checksum_source, :stop_point_ids),
-        Chouette::TimeTable.select(:id, :checksum_source, :int_day_types).includes(:dates, :periods),
-        Chouette::VehicleJourneyAtStop.select(:id, :checksum_source, :departure_time, :arrival_time, :departure_day_offset, :arrival_day_offset),
-        Chouette::VehicleJourney.select(:id, :checksum_source, :custom_field_values, :published_journey_name, :published_journey_identifier, :ignored_routing_contraint_zone_ids, :ignored_stop_area_routing_constraint_ids, :company_id).includes(:company_light, :footnotes, :vehicle_journey_at_stops, :purchase_windows)
+        Chouette::Footnote.select(:id, :checksum_source, :checksum, :code, :label),
+        Chouette::JourneyPattern.select(:id, :checksum_source, :checksum, :custom_field_values, :name, :published_name, :registration_number, :costs).includes(:stop_points),
+        Chouette::PurchaseWindow.select(:id, :checksum_source, :checksum, :name, :color, :date_ranges),
+        Chouette::Route.select(:id, :checksum_source, :checksum, :name, :published_name, :wayback).includes(:stop_points, :routing_constraint_zones),
+        Chouette::RoutingConstraintZone.select(:id, :checksum_source, :checksum, :stop_point_ids),
+        Chouette::TimeTable.select(:id, :checksum_source, :checksum, :int_day_types).includes(:dates, :periods),
+        Chouette::VehicleJourneyAtStop.select(:id, :checksum_source, :checksum, :departure_time, :arrival_time, :departure_day_offset, :arrival_day_offset),
+        Chouette::VehicleJourney.select(:id, :checksum_source, :checksum, :custom_field_values, :published_journey_name, :published_journey_identifier, :ignored_routing_contraint_zone_ids, :ignored_stop_area_routing_constraint_ids, :company_id).includes(:company_light, :footnotes, :vehicle_journey_at_stops, :purchase_windows)
       ]
       models.each do |model|
         lookup = Proc.new {
           model.find_each do |k|
             k.set_current_checksum_source(db_lookup: false)
+            k.update_checksum(force: true, silent: true)
             faulty << k if k.checksum_source_changed?
+            faulty << k if k.checksum_changed?
           end
         }
         model.klass.cache do

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,8 +15,8 @@ ActiveRecord::Schema.define(version: 20190311095017) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-  enable_extension "postgis"
   enable_extension "hstore"
+  enable_extension "postgis"
   enable_extension "unaccent"
 
   create_table "access_links", id: :bigserial, force: :cascade do |t|
@@ -109,9 +109,9 @@ ActiveRecord::Schema.define(version: 20190311095017) do
     t.integer   "organisation_id", limit: 8
     t.datetime  "created_at"
     t.datetime  "updated_at"
-    t.integer   "workgroup_id",    limit: 8
     t.integer   "int_day_types"
     t.date      "excluded_dates",                            array: true
+    t.integer   "workgroup_id",    limit: 8
     t.jsonb     "metadata",                  default: {}
   end
 
@@ -839,6 +839,7 @@ ActiveRecord::Schema.define(version: 20190311095017) do
     t.datetime  "created_at"
     t.datetime  "updated_at"
     t.daterange "periodes",                        array: true
+    t.datetime  "flagged_urgent_at"
   end
 
   add_index "referential_metadata", ["line_ids"], name: "index_referential_metadata_on_line_ids", using: :gin

--- a/lib/chouette/checksum_manager/base.rb
+++ b/lib/chouette/checksum_manager/base.rb
@@ -1,5 +1,13 @@
 module Chouette::ChecksumManager
   class Base
+    def child_after_save object
+      if object.changed? || object.destroyed?
+        parents = Chouette::ChecksumManager.checksum_parents object
+        log "Request from #{object.class.name}##{object.id} checksum updates for #{parents.count} parent(s): #{Chouette::ChecksumManager.parents_to_sentence(parents)}"
+        parents.each { |parent| Chouette::ChecksumManager.watch parent, from: object }
+      end
+    end
+
     def object_signature object
       Chouette::ChecksumManager.object_signature object
     end

--- a/lib/chouette/checksum_manager/no_updates.rb
+++ b/lib/chouette/checksum_manager/no_updates.rb
@@ -1,0 +1,9 @@
+module Chouette::ChecksumManager
+  class NoUpdates < Base
+    def watch object, _
+    end
+
+    def child_after_save object
+    end
+  end
+end

--- a/spec/models/export/gtfs_spec.rb
+++ b/spec/models/export/gtfs_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe Export::Gtfs, type: [:model, :with_exportable_referential] do
 
       random_vehicle_journey_at_stop = vehicle_journey_at_stops.sample
       stop_time = source.stop_times.detect{|stop_time| stop_time.arrival_time == GTFS::Time.format_datetime(random_vehicle_journey_at_stop.arrival_time, random_vehicle_journey_at_stop.arrival_day_offset, 'Europe/Paris') }
-      expect(stop_time).not_to be_nil
+      expect(stop_time).not_to be_nil, "Did not find stop with time #{GTFS::Time.format_datetime(random_vehicle_journey_at_stop.arrival_time, random_vehicle_journey_at_stop.arrival_day_offset, 'Europe/Paris') } among #{source.stop_times.map(&:arrival_time)}"
       expect(stop_time.departure_time).to eq(GTFS::Time.format_datetime(random_vehicle_journey_at_stop.departure_time, random_vehicle_journey_at_stop.departure_day_offset, 'Europe/Paris'))
     end
   end

--- a/spec/models/import/gtfs_spec.rb
+++ b/spec/models/import/gtfs_spec.rb
@@ -349,7 +349,6 @@ RSpec.describe Import::Gtfs do
     before do
       import.prepare_referential
       import.import_calendars
-      allow(import).to receive(:save_model).and_wrap_original { |m, model| m.call(model); model.run_callbacks(:commit) }
     end
 
     it 'should store the trips in memory' do
@@ -429,6 +428,7 @@ RSpec.describe Import::Gtfs do
 
     it "should create a VehicleJourneyAtStop for each stop_time" do
       import.import_stop_times
+      import.import_missing_checksums
 
       def t(value)
         Time.parse(value)


### PR DESCRIPTION
You can now use `Import::Gtfs.profile(filepath, options)` in the console 
to easily run an import and get infos about where the time is spent