### PR TITLE
10376 Purge old referentials

### DIFF
--- a/app/lib/cron.rb
+++ b/app/lib/cron.rb
@@ -92,5 +92,11 @@ module Cron
         Delayed::Heartbeat::Worker.handle_dead_workers
       end
     end
+
+    def purge_referentials
+      protected_action do
+        Referential.clean!
+      end
+    end
   end
 end

--- a/app/lib/cron.rb
+++ b/app/lib/cron.rb
@@ -95,7 +95,9 @@ module Cron
 
     def purge_referentials
       protected_action do
-        Referential.clean!
+        Workbench.find_each do |w|
+          w.referentials.clean!
+        end
       end
     end
   end

--- a/app/lib/smart_env.rb
+++ b/app/lib/smart_env.rb
@@ -17,10 +17,15 @@ module SmartEnv
     @boolean_keys ||= []
   end
 
+  def self.integer_keys
+    @integer_keys ||= []
+  end
+
   def self.reset!
     @keys = nil
     @required_keys = nil
     @boolean_keys = nil
+    @integer_keys = nil
     @default_values = nil
   end
 
@@ -39,6 +44,10 @@ module SmartEnv
       boolean_keys.delete key
       boolean_keys << key if opts[:boolean]
     end
+    if opts.has_key?(:integer)
+      integer_keys.delete key
+      integer_keys << key if opts[:integer]
+    end
     if opts.has_key?(:default)
       default_values[key] = opts[:default]
     end
@@ -50,6 +59,10 @@ module SmartEnv
 
   def self.add_boolean key, opts={}
     self.add key, opts.update({boolean: true})
+  end
+
+  def self.add_integer key, opts={}
+    self.add key, opts.update({integer: true})
   end
 
   def self.check!
@@ -79,6 +92,7 @@ module SmartEnv
 
     val = ENV.fetch(key, nil) || default || default_values[key]
     val = cast_boolean(val) if opts[:boolean] || boolean_keys.include?(key)
+    val = cast_integer(val) if opts[:integer] || integer_keys.include?(key)
     val
   end
 
@@ -96,6 +110,10 @@ module SmartEnv
     return false if EXPLICITLY_FALSE_VALUES.include?(value)
     return value.present? if value.is_a?(String)
     !!value
+  end
+
+  def self.cast_integer value
+    value.to_i
   end
 
   class MissingKey < Exception

--- a/app/models/referential.rb
+++ b/app/models/referential.rb
@@ -41,6 +41,7 @@ class Referential < ApplicationModel
 
   attr_accessor :from_current_offer
   attr_accessor :urgent
+  attr_accessor :bare #this is used in specs to skip schema creation
 
   has_one :user
   has_many :import_resources, class_name: 'Import::Resource', dependent: :destroy
@@ -527,7 +528,7 @@ class Referential < ApplicationModel
   end
 
   def create_schema
-    return if created_from
+    return if created_from || bare
 
     report = Benchmark.measure do
       Apartment::Tenant.create slug

--- a/config/application.rb
+++ b/config/application.rb
@@ -61,6 +61,7 @@ module ChouetteIhm
     SmartEnv.add :DELAYED_JOB_REAPER_HEARTBEAT_INTERVAL_SECONDS, default: 20
     SmartEnv.add :DELAYED_JOB_REAPER_HEARTBEAT_TIMEOUT_SECONDS, default: 60
     SmartEnv.add_boolean :DELAYED_JOB_REAPER_WORKER_TERMINATION_ENABLED, default: true
+    SmartEnv.add_integer :REFERENTIALS_CLEANING_COOLDOWN
 
     config.i18n.default_locale = SmartEnv[:RAILS_LOCALE].to_sym
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -7,6 +7,7 @@ Rails.application.configure do
   SmartEnv.set :IEV_URL, default: "http://localhost:8080"
   SmartEnv.add_boolean :TOOLBAR
   SmartEnv.set :BYPASS_AUTH_FOR_SIDEKIQ, default: true
+  SmartEnv.set :REFERENTIALS_CLEANING_COOLDOWN, default: 30
 
   # In the development environment your application's code is reloaded on
   # every request. This slows down response time but is perfect for development

--- a/config/initializers/cron.rb
+++ b/config/initializers/cron.rb
@@ -1,2 +1,2 @@
 Cron.every_5_minutes :check_import_operations, :check_ccset_operations, :check_nightly_aggregates, :handle_dead_workers
-Cron.every_day_at_3AM :audit_referentials
+Cron.every_day_at_3AM :purge_referentials, :audit_referentials

--- a/spec/factories/merges.rb
+++ b/spec/factories/merges.rb
@@ -1,6 +1,15 @@
 FactoryGirl.define do
   factory :merge do
     workbench
-    new { factory :referential }
+
+    transient do
+      new nil
+    end
+
+    after(:create) do |merge, evaluator|
+      if evaluator.new
+        merge.update new: evaluator.new
+      end
+    end
   end
 end

--- a/spec/factories/referentials.rb
+++ b/spec/factories/referentials.rb
@@ -13,6 +13,10 @@ FactoryGirl.define do
       status :active
     end
 
+    trait :bare do
+      bare true
+    end
+
     after(:create) do |referential, evaluator|
       referential.send "#{evaluator.status}!"
     end

--- a/spec/models/referential_spec.rb
+++ b/spec/models/referential_spec.rb
@@ -5,6 +5,113 @@ describe Referential, :type => :model do
   it { should belong_to(:workbench) }
   it { should belong_to(:referential_suite) }
 
+  context '#clean_scope' do
+    let(:cooldown){ 30 }
+    before(:each) do
+       Referential.send :remove_const, 'TIME_BEFORE_CLEANING'
+       Referential.const_set 'TIME_BEFORE_CLEANING', cooldown
+     end
+
+    it 'should be empty' do
+      create(:referential, :bare)
+      expect(Referential.clean_scope).to be_empty
+    end
+
+    context 'with an old Referential' do
+      let(:old_referential) do
+        old_referential = create(:referential, :bare)
+        old_referential.active!
+        old_referential
+      end
+
+      context 'archived' do
+        before { old_referential.archived! }
+        it 'should not contain it' do
+          expect(Referential.clean_scope).to_not include old_referential
+        end
+
+        context "with #{Referential::KEPT_DURING_CLEANING} referentials after" do
+          before do
+            create_list(:referential, Referential::KEPT_DURING_CLEANING)
+          end
+
+          it 'should not contain it' do
+            expect(Referential.clean_scope).to_not include old_referential
+          end
+        end
+
+        context 'used in a merged offer' do
+          before do
+            other_referential = create(:referential, :bare)
+            create(:referential_metadata, referential: other_referential, referential_source: old_referential)
+          end
+          it 'should not contain it' do
+            expect(Referential.clean_scope).to_not include old_referential
+          end
+        end
+      end
+
+      context 'archived more than a month ago' do
+        before(:each) do
+           old_referential.archived!
+           old_referential.update archived_at: Referential::TIME_BEFORE_CLEANING.days.ago.prev_day
+         end
+
+        it 'should not contain it' do
+          expect(Referential.clean_scope).to_not include old_referential
+        end
+
+        context "with #{Referential::KEPT_DURING_CLEANING} referentials after" do
+          before do
+            old_referential
+            create_list(:referential, Referential::KEPT_DURING_CLEANING, :bare)
+          end
+
+          it 'should contain it' do
+            expect(Referential.clean_scope).to include old_referential
+          end
+
+          context 'with Referential::KEPT_DURING_CLEANING zeroed' do
+            let(:cooldown){ 0 }
+
+            it 'should be empty' do
+              expect(Referential.clean_scope).to be_empty
+            end
+          end
+
+          context 'used in a merged offer' do
+            before do
+              other_referential = create(:referential, :bare)
+              create(:referential_metadata, referential: other_referential, referential_source: old_referential)
+            end
+            it 'should not contain it' do
+              expect(Referential.clean_scope).to_not include old_referential
+            end
+          end
+        end
+      end
+
+      context 'active' do
+        before { old_referential.active! }
+
+        it 'should not contain it' do
+          expect(Referential.clean_scope).to_not include old_referential
+        end
+
+        context "with #{Referential::KEPT_DURING_CLEANING} referentials after" do
+          before do
+            old_referential
+            create_list(:referential, Referential::KEPT_DURING_CLEANING, :bare)
+          end
+
+          it 'should not contain it' do
+            expect(Referential.clean_scope).to_not include old_referential
+          end
+        end
+      end
+    end
+  end
+
   context "validation" do
     subject { build_stubbed(:referential) }
 

--- a/spec/models/referential_spec.rb
+++ b/spec/models/referential_spec.rb
@@ -19,7 +19,7 @@ describe Referential, :type => :model do
 
     context 'with an old Referential' do
       let(:old_referential) do
-        old_referential = create(:referential, :bare)
+        old_referential = create(:workbench_referential, :bare)
         old_referential.active!
         old_referential
       end
@@ -69,6 +69,14 @@ describe Referential, :type => :model do
 
           it 'should contain it' do
             expect(Referential.clean_scope).to include old_referential
+          end
+
+          context 'scoped in a workbench' do
+            it 'should only account for referentials in the workbench' do
+              expect(old_referential.workbench.referentials.clean_scope).to_not include old_referential
+              create_list(:workbench_referential, Referential::KEPT_DURING_CLEANING, :bare, workbench: old_referential.workbench)
+              expect(old_referential.workbench.referentials.clean_scope).to include old_referential
+            end
           end
 
           context 'with Referential::KEPT_DURING_CLEANING zeroed' do

--- a/spec/models/referential_spec.rb
+++ b/spec/models/referential_spec.rb
@@ -515,7 +515,7 @@ describe Referential, :type => :model do
   context "lines" do
     describe "search" do
       it "should support Ransack search method" do
-        expect(ref.lines.search.result.to_a).to eq(ref.lines.to_a)
+        expect(ref.lines.ransack.result.to_a).to eq(ref.lines.to_a)
       end
     end
   end


### PR DESCRIPTION
Automatically destroy old referentials once a day if the 
REFERENTIALS_CLEANING_COOLDOWN env variable is set up, with a value 
corresponding to the number of days the referentials must be retained