### PR TITLE
12015 - New codifligne format regarding netex lines pre-parsing

### DIFF
--- a/app/controllers/api/v1/internals/netex_imports_controller.rb
+++ b/app/controllers/api/v1/internals/netex_imports_controller.rb
@@ -89,7 +89,7 @@ module Api
             if frame
               metadata.periodes = frame.periods
 
-              line_objectids = frame.line_refs.map { |ref| "STIF:CODIFLIGNE:Line:#{ref}" }
+              line_objectids = frame.line_refs.map { |ref| "FR1:Line:#{ref}:" }
               metadata.line_ids = @workbench.lines.where(objectid: line_objectids).pluck(:id)
             end
           end

--- a/app/models/import/netex.rb
+++ b/app/models/import/netex.rb
@@ -113,7 +113,7 @@ class Import::Netex < Import::Base
       if frame
         metadata.periodes = frame.periods
 
-        @line_objectids = frame.line_refs.map { |ref| "STIF:CODIFLIGNE:Line:#{ref}" }
+        @line_objectids = frame.line_refs.map { |ref| "FR1:Line:#{ref}:" }
         metadata.line_ids = workbench.lines.where(objectid: @line_objectids).pluck(:id)
       end
     end


### PR DESCRIPTION
https://projects.af83.io/issues/12015

Juste un fix, car rails vérifiait le format des objetcid de lignes lors du pre-processing de l'import netex avant de faire appel à IEV. Il reste encore dans la partie rails beaucoup de référence à l'ancien format (STIF:CODIFLIGNE), mais mieux vaudrait faire un ticket spécifique pour celà.
 